### PR TITLE
Enable top-level imports

### DIFF
--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -3,5 +3,5 @@ __version__ = "0.1.0"
 from .io.parser import load_context
 
 __all__ = [
-  "load_context",
+    "load_context",
 ]

--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -1,1 +1,7 @@
 __version__ = "0.1.0"
+
+from .io.parser import load_context
+
+__all__ = [
+  "load_context",
+]

--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -1,11 +1,12 @@
 from importlib import metadata
+
 from .io.parser import load_context
 
 try:
     from importlib.metadata import version
 except ImportError:  # for Python<3.8
     from importlib_metadata import version
-    
+
 __all__ = [
     "load_context",
 ]

--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -1,5 +1,3 @@
-from importlib import metadata
-
 from .io.parser import load_context
 
 try:


### PR DESCRIPTION
It's not very ergonomic to have to know two subpackages to get the most standard functionality. This PR replaces the need to do this

```python
from prefixmaps.io.parser import load_context
```

with the more ergonomic

```python
from prefixmaps import load_context
```
