### PR TITLE
Improve package navigability

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-from prefixmaps.io.parser import load_context, load_multi_context  # noqa F401

--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -1,4 +1,5 @@
-from .io.parser import load_context
+from .io.parser import load_context, load_multi_context
+from .datamodel.context import Context, StatusType, PrefixExpansion
 
 try:
     from importlib.metadata import version
@@ -7,5 +8,9 @@ except ImportError:  # for Python<3.8
 
 __all__ = [
     "load_context",
+    "load_multi_context",
+    "Context",
+    "StatusType",
+    "PrefixExpansion",
 ]
 __version__ = version(__name__)

--- a/src/prefixmaps/__init__.py
+++ b/src/prefixmaps/__init__.py
@@ -1,5 +1,5 @@
+from .datamodel.context import Context, PrefixExpansion, StatusType
 from .io.parser import load_context, load_multi_context
-from .datamodel.context import Context, StatusType, PrefixExpansion
 
 try:
     from importlib.metadata import version

--- a/src/prefixmaps/datamodel/context.py
+++ b/src/prefixmaps/datamodel/context.py
@@ -3,6 +3,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Mapping, Optional
 
+__all__ = [
+    "StatusType",
+    "PrefixExpansion",
+    "Context",
+]
+
 CONTEXT = str
 PREFIX = str
 NAMESPACE = str

--- a/src/prefixmaps/io/parser.py
+++ b/src/prefixmaps/io/parser.py
@@ -8,6 +8,11 @@ from prefixmaps.data import data_path
 from prefixmaps.datamodel.context import CONTEXT, Context, PrefixExpansion, StatusType
 
 
+__all__ = [
+    "load_multi_context",
+    "load_context",
+]
+
 def context_path(name: CONTEXT) -> Path:
     """
     Get the path in which the context datafile lives

--- a/src/prefixmaps/io/parser.py
+++ b/src/prefixmaps/io/parser.py
@@ -7,11 +7,11 @@ import yaml
 from prefixmaps.data import data_path
 from prefixmaps.datamodel.context import CONTEXT, Context, PrefixExpansion, StatusType
 
-
 __all__ = [
     "load_multi_context",
     "load_context",
 ]
+
 
 def context_path(name: CONTEXT) -> Path:
     """


### PR DESCRIPTION
This PR does three things:

1. Removes a redundant/confusing `__init__.py` outside of the package structure
2. Adds more explicit exports (i.e., by specifying `__all__` in some modules)
3. Make more useful classes available from top level by importing in the package-level `__init__.py`