### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
       #    install your root project, if required 
       #----------------------------------------------      
       - name: Install library
-        run: poetry install --no-interaction --extras gilda
+        run: poetry install --no-interaction --extras refresh
 
       #----------------------------------------------
       #              run test suite   

--- a/poetry.lock
+++ b/poetry.lock
@@ -78,7 +78,7 @@ lxml = ["lxml"]
 name = "bioregistry"
 version = "0.5.143"
 description = "Integrated registry of biological databases and nomenclatures"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -182,7 +182,7 @@ toml = ["tomli"]
 name = "curies"
 version = "0.3.0"
 description = "Idiomatic conversion between URIs and compact URIs (CURIEs)."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -363,7 +363,7 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -460,7 +460,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "jsonschema"
-version = "4.16.0"
+version = "4.17.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -544,7 +544,7 @@ linkml-runtime = ">=1.1.6"
 
 [[package]]
 name = "linkml-runtime"
-version = "1.3.5"
+version = "1.3.6"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 category = "dev"
 optional = false
@@ -620,7 +620,7 @@ python-versions = ">=3.7"
 name = "more-click"
 version = "0.1.1"
 description = "More click."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -692,7 +692,7 @@ python-versions = "*"
 name = "pickle5"
 version = "0.0.12"
 description = "Backport of the pickle 5 protocol (PEP 574) and other pickle changes"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5, <3.8"
 
@@ -764,7 +764,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pydantic"
 version = "1.10.2"
 description = "Data validation and settings management using python type hints"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -856,7 +856,7 @@ shexjsg = ">=0.8.1"
 name = "pystow"
 version = "0.4.7"
 description = "Easily pick a place to store data for your python package."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -923,7 +923,7 @@ six = ">=1.5"
 name = "pytrie"
 version = "0.4.0"
 description = "A pure Python implementation of the trie data structure."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -950,7 +950,7 @@ python-versions = ">=3.6"
 name = "rdflib"
 version = "6.2.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1055,7 +1055,7 @@ python-versions = ">=3.5"
 name = "setuptools"
 version = "65.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1079,7 +1079,7 @@ pyjsg = ">=0.11.10"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -1095,7 +1095,7 @@ python-versions = "*"
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1172,19 +1172,19 @@ test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "1.19.4"
+version = "1.19.5"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-furo = {version = ">=2022.9.15", optional = true, markers = "extra == \"docs\""}
-sphinx = ">=5.2.1"
+furo = {version = ">=2022.9.29", optional = true, markers = "extra == \"docs\""}
+sphinx = ">=5.3"
 
 [package.extras]
-docs = ["furo (>=2022.9.15)", "sphinx (>=5.2.1)", "sphinx-autodoc-typehints (>=1.19.3)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.4)", "diff-cover (>=7.0.1)", "nptyping (>=2.3.1)", "pytest (>=7.1.3)", "pytest-cov (>=3)", "sphobjinv (>=2.2.2)", "typing-extensions (>=4.3)"]
+docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.5)", "diff-cover (>=7.0.1)", "nptyping (>=2.3.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "sphobjinv (>=2.2.2)", "typing-extensions (>=4.4)"]
 type-comment = ["typed-ast (>=1.5.4)"]
 
 [[package]]
@@ -1216,18 +1216,18 @@ sphinx = ">=2.0"
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.0.0"
+version = "1.1.0"
 description = "Read the Docs theme for Sphinx"
 category = "main"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
 docutils = "<0.18"
-sphinx = ">=1.6"
+sphinx = ">=1.6,<6"
 
 [package.extras]
-dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
+dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client", "wheel"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -1383,7 +1383,7 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psu
 name = "tqdm"
 version = "4.64.1"
 description = "Fast, Extensible Progress Meter"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
@@ -1495,13 +1495,12 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [extras]
 docs = ["Sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "sphinx-click", "myst-parser"]
-gilda = []
-refresh = ["click"]
+refresh = ["requests", "bioregistry", "rdflib"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.6"
-content-hash = "79067a8808fa3c5e4af48d6679981ea41d5e87e8bed796b88efb7cf057084a40"
+content-hash = "0025321c980b80b5e7f8f8c943aec3f17b29fcadaddc880a7b7ef7f8cc2e06fb"
 
 [metadata.files]
 alabaster = [
@@ -1768,8 +1767,8 @@ jsonpointer = [
     {file = "jsonpointer-2.3.tar.gz", hash = "sha256:97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.16.0-py3-none-any.whl", hash = "sha256:9e74b8f9738d6a946d70705dc692b74b5429cd0960d58e79ffecfc43b2221eb9"},
-    {file = "jsonschema-4.16.0.tar.gz", hash = "sha256:165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23"},
+    {file = "jsonschema-4.17.0-py3-none-any.whl", hash = "sha256:f660066c3966db7d6daeaea8a75e0b68237a48e51cf49882087757bb59916248"},
+    {file = "jsonschema-4.17.0.tar.gz", hash = "sha256:5bfcf2bca16a087ade17e02b282d34af7ccd749ef76241e7f9bd7c0cb8a9424d"},
 ]
 linkml = [
     {file = "linkml-1.3.12-py3-none-any.whl", hash = "sha256:4ac6dec02e588cf4a006a0aec0045f35cfb2c7979a3cfcacbf96303db3ff626a"},
@@ -1780,8 +1779,8 @@ linkml-dataops = [
     {file = "linkml_dataops-0.1.0.tar.gz", hash = "sha256:4550eab65e78b70dc3b9c651724a94ac2b1d1edb2fbe576465f1d6951a54ed04"},
 ]
 linkml-runtime = [
-    {file = "linkml-runtime-1.3.5.tar.gz", hash = "sha256:b5bea074d6261f55b8b83a512be88edf4144574e32b9f014f0e46d1143a0d93f"},
-    {file = "linkml_runtime-1.3.5-py3-none-any.whl", hash = "sha256:cc951cf1379bc3652358913061f8e1d251d99f558e428793b06c7b0a88224e51"},
+    {file = "linkml-runtime-1.3.6.tar.gz", hash = "sha256:3bc5c4d1fa7131df4e17956cbb3151bdaf08511109707e41fdf8339299e8e973"},
+    {file = "linkml_runtime-1.3.6-py3-none-any.whl", hash = "sha256:cabeb10c25d7337247db78ea776f78af93f3e08c7a9770f7b4508c95f4cabb98"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
@@ -2159,8 +2158,8 @@ sphinx = [
     {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
 ]
 sphinx-autodoc-typehints = [
-    {file = "sphinx_autodoc_typehints-1.19.4-py3-none-any.whl", hash = "sha256:e190d8ee8204c3de05a64f41cf10e592e987e4063c8ec0de7e4b11f6e036b2e2"},
-    {file = "sphinx_autodoc_typehints-1.19.4.tar.gz", hash = "sha256:ffd8e710f6757471b5c831c7ece88f52a9ff15f27836f4ef1c8695a64f8dcca8"},
+    {file = "sphinx_autodoc_typehints-1.19.5-py3-none-any.whl", hash = "sha256:ea55b3cc3f485e3a53668bcdd08de78121ab759f9724392fdb5bf3483d786328"},
+    {file = "sphinx_autodoc_typehints-1.19.5.tar.gz", hash = "sha256:38a227378e2bc15c84e29af8cb1d7581182da1107111fd1c88b19b5eb7076205"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-1.0.0b1-py3-none-any.whl", hash = "sha256:ade597a3029c7865b24ad0eda88318766bcc2f9f4cef60df7e28126fde94db2a"},
@@ -2171,8 +2170,8 @@ sphinx-click = [
     {file = "sphinx_click-4.3.0-py3-none-any.whl", hash = "sha256:23e85a3cb0b728a421ea773699f6acadefae171d1a764a51dd8ec5981503ccbe"},
 ]
 sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-1.0.0-py2.py3-none-any.whl", hash = "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8"},
-    {file = "sphinx_rtd_theme-1.0.0.tar.gz", hash = "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"},
+    {file = "sphinx_rtd_theme-1.1.0-py2.py3-none-any.whl", hash = "sha256:36da4267c804b98197419df8aa415d245449b8945301fce8c961038e0ba79ec5"},
+    {file = "sphinx_rtd_theme-1.1.0.tar.gz", hash = "sha256:6e20f00f62b2c05434a33c5116bc3348a41ca94af03d3d7d1714c63457073bb3"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ sphinx-click = {version = "^4.3.0", extras = ["docs"]}
 myst-parser = {version = "^0.18.1", extras = ["docs"]}
 click = "^8.1.3"
 requests = {version = "^2.28.1", extras = ["refresh"]}
+# Anticipate bioregistry ^0.6.0 will require adaptation
 bioregistry = {version = "<0.6.0", extras = ["refresh"]}
 rdflib = {version = "^6.2.0", extras = ["refresh"]}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,12 @@ sphinx-autodoc-typehints = {version = "^1.19.4", extras = ["docs"]}
 sphinx-click = {version = "^4.3.0", extras = ["docs"]}
 myst-parser = {version = "^0.18.1", extras = ["docs"]}
 click = "^8.1.3"
+requests = {version = "^2.28.1", extras = ["refresh"]}
+bioregistry = {version = "<0.6.0", extras = ["refresh"]}
+rdflib = {version = "^6.2.0", extras = ["refresh"]}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
-bioregistry = "^0.5.54"
 linkml = "^1.3.1"
 curies = "^0.3.0"
 coverage = "^6.4.4"
@@ -41,11 +43,11 @@ docs = [
     "sphinx-autodoc-typehints",
     "sphinx-click",
     "myst-parser"
-    ]
-gilda = ["gilda"]
+]
 refresh = [
-    "click",
-    "bioregistry"
+    "requests",
+    "bioregistry",
+    "rdflib"
 ]
 
 [tool.black]


### PR DESCRIPTION
This makes the requirements for refreshing more explicit. It also puts a cap on the bioregistry version since some code will need to be updated to upgrade to 0.6.* series