### PR TITLE
remove importlib dependency to avoid version conflicts when adding to linkml_runtime

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1501,7 +1501,7 @@ refresh = ["requests", "bioregistry", "rdflib"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.6"
-content-hash = "58890475bd159172c91ca31940f35dc229233d370b2f1761f0071a5720abaa17"
+content-hash = "74bf394147bd38415cd9915f3c14c5d0c910b5aab013b7567a6738153f5678ef"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ homepage = "https://github.com/linkml/prefixmaps"
 [tool.poetry.dependencies]
 python = "^3.7.6"
 pyyaml = ">=5.3.1"
+importlib-metadata = ">=1.0.0"
 sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"]}
 Sphinx = {version = "^5.3.0", extras = ["docs"]}
 sphinx-autodoc-typehints = {version = "^1.19.4", extras = ["docs"]}


### PR DESCRIPTION
tests pass in all python supported versions
when installing locally, I get `importlib-metadata 5.1.0`

related to: https://github.com/linkml/linkml-runtime/pull/231