### PR TITLE
fix: align declared supported python versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.11", "3.7" ]
+        python-version: [ "3.11", "3.9" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.11", "3.8" ]
+        python-version: [ "3.12", "3.11", "3.9" ]
 
     steps:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.7",
 ]
 
 [tool.poetry.urls]

--- a/src/prefixmaps/ingest/etl_runner.py
+++ b/src/prefixmaps/ingest/etl_runner.py
@@ -1,4 +1,5 @@
 """ETL logic for retrieving and normalizing upstream contexts."""
+
 from pathlib import Path
 from typing import Callable, Dict, Mapping, Union
 

--- a/src/prefixmaps/ingest/ingest_bioportal.py
+++ b/src/prefixmaps/ingest/ingest_bioportal.py
@@ -1,4 +1,5 @@
 """Simple ETL from bioportal to prefixmaps."""
+
 from typing import Any, Dict, TextIO, Union
 
 from prefixmaps.data import data_path

--- a/src/prefixmaps/ingest/ingest_go.py
+++ b/src/prefixmaps/ingest/ingest_go.py
@@ -1,4 +1,5 @@
 """Ingests the GO prefix registry."""
+
 from typing import TextIO, Union
 
 import requests

--- a/src/prefixmaps/ingest/ingest_jsonld.py
+++ b/src/prefixmaps/ingest/ingest_jsonld.py
@@ -1,4 +1,5 @@
 """Generic JSON-LD ingests."""
+
 import json
 from typing import Any, Dict, List, Optional, TextIO, Union
 

--- a/src/prefixmaps/ingest/ingest_shacl.py
+++ b/src/prefixmaps/ingest/ingest_shacl.py
@@ -1,4 +1,5 @@
 """Ingests from triples using the SHACL PrefixDeclarations data model."""
+
 from typing import Any, TextIO, Union
 
 import rdflib

--- a/tests/test_core/test_prefixmaps.py
+++ b/tests/test_core/test_prefixmaps.py
@@ -1,6 +1,7 @@
 """Tests core expansion logic and data.
 This serves as "checksums" on the underlying ingested data.
 """
+
 import unittest
 
 import prefixmaps


### PR DESCRIPTION
Poetry specifies that only Python versions from 3.9 upwards are supported. But the package metadata (mostly visible over PyPI) was still declaring support for Python 3.7 and 3.8.

This patch fixes it.