### PR TITLE
Cut call time of `add_prefix()` by 99.8%

### DIFF
--- a/src/prefixmaps/datamodel/context.py
+++ b/src/prefixmaps/datamodel/context.py
@@ -143,13 +143,13 @@ class Context:
     merged_from: Optional[List[str]] = None
     upper: bool = None
     lower: bool = None
-    _prefixes: Optional[Set[str]] = None
+    _prefixes: Set[str] = field(default_factory=set)
     """Private attr to speed up duplicate lookups"""
-    _prefixes_lower: Optional[Set[str]] = None
+    _prefixes_lower: Set[str] = field(default_factory=set)
     """Private attr to speed up duplicate lookups"""
-    _namespaces: Optional[Set[str]] = None
+    _namespaces: Set[str] = field(default_factory=set)
     """Private attr to speed up duplicate lookups"""
-    _namespaces_lower: Optional[Set[str]] = None
+    _namespaces_lower: Set[str] = field(default_factory=set)
     """Private attr to speed up duplicate lookups"""
 
     def combine(self, context: "Context"):
@@ -256,12 +256,12 @@ class Context:
         :return:
         """
         if lower:
-            if force or self._prefixes_lower is None:
+            if force or len(self._prefixes_lower) == 0:
                 self._prefixes_lower = {pe.prefix.lower() for pe in self.prefix_expansions}
             res = self._prefixes_lower
 
         else:
-            if force or self._prefixes is None:
+            if force or len(self._prefixes) == 0:
                 self._prefixes = {pe.prefix for pe in self.prefix_expansions}
             res = self._prefixes
 
@@ -280,12 +280,12 @@ class Context:
         :return:
         """
         if lower:
-            if force or self._namespaces_lower is None:
+            if force or len(self._namespaces_lower) == 0:
                 self._namespaces_lower = {pe.namespace.lower() for pe in self.prefix_expansions}
             res = self._namespaces_lower
 
         else:
-            if force or self._namespaces is None:
+            if force or len(self._namespaces) == 0:
                 self._namespaces = {pe.namespace for pe in self.prefix_expansions}
             res = self._namespaces
 

--- a/src/prefixmaps/datamodel/context.py
+++ b/src/prefixmaps/datamodel/context.py
@@ -1,4 +1,5 @@
 """Classes for managing individual Contexts."""
+
 import logging
 import re
 from collections import defaultdict
@@ -171,7 +172,7 @@ class Context:
         status: StatusType = StatusType.canonical,
         preferred: bool = False,
         expansion_source: Optional[str] = None,
-        force: bool = False
+        force: bool = False,
     ):
         """
         Adds a prefix expansion to this context.
@@ -245,7 +246,9 @@ class Context:
             filtered_pes.append(pe)
         return filtered_pes
 
-    def prefixes(self, lower=False, force:bool = True, as_list: bool = True) -> Union[List[str], Set[str]]:
+    def prefixes(
+        self, lower=False, force: bool = True, as_list: bool = True
+    ) -> Union[List[str], Set[str]]:
         """
         All unique prefixes in all prefix expansions.
 
@@ -269,7 +272,9 @@ class Context:
         else:
             return res
 
-    def namespaces(self, lower=False, force:bool = True, as_list:bool = True) -> Union[List[str], Set[str]]:
+    def namespaces(
+        self, lower=False, force: bool = True, as_list: bool = True
+    ) -> Union[List[str], Set[str]]:
         """
         All unique namespaces in all prefix expansions
 
@@ -292,7 +297,6 @@ class Context:
             return list(res)
         else:
             return res
-
 
     def as_dict(self) -> PREFIX_EXPANSION_DICT:
         """

--- a/src/prefixmaps/datamodel/context.py
+++ b/src/prefixmaps/datamodel/context.py
@@ -1,5 +1,4 @@
 """Classes for managing individual Contexts."""
-import copy
 import logging
 import re
 from collections import defaultdict
@@ -268,7 +267,7 @@ class Context:
         if as_list:
             return list(res)
         else:
-            return copy.copy(res)
+            return res
 
     def namespaces(self, lower=False, force:bool = True, as_list:bool = True) -> Union[List[str], Set[str]]:
         """
@@ -292,7 +291,7 @@ class Context:
         if as_list:
             return list(res)
         else:
-            return copy.copy(res)
+            return res
 
 
     def as_dict(self) -> PREFIX_EXPANSION_DICT:


### PR DESCRIPTION
Fix: https://github.com/linkml/prefixmaps/issues/68

Previously on perf hunting: we had stumbled across a method in the wild that seemed harmless enough, but upon getting closer it turned to attack and we saw that it was in fact O(2n^2) in disguise!!

On this episode: we propose a function-neutral change that looks the same to an external observer (eg. someone that calls and of the public methods `combine()`, `prefixes()`, or `namespaces()` methods directly) but internally within the `add_prefix` method we avoid set comprehensions that become very expensive as the `namespaces` or `prefixes` sets become large. 

For `Run on the `linkml` tests `--with-slow` enabled, no tests fail and...
Current version: 156s (cumulative), 0.00580s per call
This PR: 0.2s (cumulative), 7.75e-06s per call
Change: -155.2s, 99.8% decrease