### PR TITLE
refresh contexts based on GO changes upstream

### DIFF
--- a/src/prefixmaps/data/go.csv
+++ b/src/prefixmaps/data/go.csv
@@ -20,6 +20,7 @@ go,FMA,http://purl.obolibrary.org/obo/FMA_,canonical
 go,FYPO,http://purl.obolibrary.org/obo/FYPO_,canonical
 go,GeneDB,http://identifiers.org/genedb/,canonical
 go,GO,http://purl.obolibrary.org/obo/GO_,canonical
+go,GO_REF,http://purl.obolibrary.org/obo/go/references/,canonical
 go,gomodel,http://model.geneontology.org/,canonical
 go,GR_GENE,http://identifiers.org/gramene.gene/,canonical
 go,GR_PROTEIN,http://identifiers.org/gramene.protein/,canonical
@@ -39,6 +40,7 @@ go,NCBITaxon,http://purl.obolibrary.org/obo/NCBITaxon_,canonical
 go,PANTHER,http://identifiers.org/panther.family/,canonical
 go,PATO,http://purl.obolibrary.org/obo/PATO_,canonical
 go,PlasmoDB,http://identifiers.org/plasmodb/,canonical
+go,PMID,http://identifiers.org/pubmed/,canonical
 go,PO,http://purl.obolibrary.org/obo/PO_,canonical
 go,PomBase,http://identifiers.org/pombase/,canonical
 go,PR,http://purl.obolibrary.org/obo/PR_,canonical
@@ -50,6 +52,7 @@ go,SGN,http://identifiers.org/sgn/,canonical
 go,SO,http://purl.obolibrary.org/obo/SO_,canonical
 go,TAIR,http://identifiers.org/tair.locus/,canonical
 go,TGD,http://identifiers.org/tgd/,canonical
+go,TreeGrafter,http://identifiers.org/panther.family/,namespace_alias
 go,TriTrypDB,http://identifiers.org/tritrypdb/,canonical
 go,UBERON,http://purl.obolibrary.org/obo/UBERON_,canonical
 go,UniProtKB,http://identifiers.org/uniprot/,canonical

--- a/src/prefixmaps/data/merged.csv
+++ b/src/prefixmaps/data/merged.csv
@@ -185,6 +185,7 @@ merged,AfPO,http://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged,AfPO,https://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged,AfPO,https://purl.obolibrary.org/obo/AfPO_,prefix_alias,bioregistry
 merged,afr,http://purl.allotrope.org/ontologies/result#,canonical,prefixcc
+merged,after,http://rds.posccaesar.org/ontology/plm/ds/,canonical,prefixcc
 merged,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy/,canonical,bioregistry
 merged,AFTOL.TAXONOMY,http://bioregistry.io/aftol.taxonomy:,prefix_alias,bioregistry
 merged,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy:,prefix_alias,bioregistry
@@ -251,7 +252,9 @@ merged,AIO,https://w3id.org/aio/,canonical,bioregistry
 merged,AIO,http://bioregistry.io/aio:,prefix_alias,bioregistry
 merged,AIO,http://w3id.org/aio/,prefix_alias,bioregistry
 merged,AIO,https://bioregistry.io/aio:,prefix_alias,bioregistry
+merged,aio,https://paul.ti.rw.fau.de/~jo00defe/SemWoT/aio#,prefix_alias,prefixcc
 merged,air,http://dig.csail.mit.edu/TAMI/2007/amord/air#,canonical,prefixcc
+merged,airo,https://w3id.org/airo#,canonical,prefixcc
 merged,airport,http://www.daml.org/2001/10/html/airport-ont#,canonical,prefixcc
 merged,airs,https://raw.githubusercontent.com/airs-linked-data/lov/latest/src/airs_vocabulary.ttl#,canonical,prefixcc
 merged,AISM,http://purl.obolibrary.org/obo/AISM_,canonical,obo
@@ -319,6 +322,7 @@ merged,AMPHX,https://www.ebi.ac.uk/ols/ontologies/amphx/terms?iri=http://purl.ob
 merged,ams,http://data.amadeus.com/,canonical,prefixcc
 merged,amsl,http://vocab.ub.uni-leipzig.de/amsl/,canonical,prefixcc
 merged,amt,http://academic-meta-tool.xyz/vocab#,canonical,prefixcc
+merged,amv,https://w3id.org/amv/,canonical,prefixcc
 merged,anca,http://users.utcluj.ro/~raluca/rdf_ontologies_ralu/ralu_modified_ontology_pizzas2_0#,canonical,prefixcc
 merged,aneo,http://akonadi-project.org/ontologies/aneo#,canonical,prefixcc
 merged,ann,http://www.w3.org/2000/10/annotation-ns#,canonical,prefixcc
@@ -422,6 +426,7 @@ merged,api,http://purl.org/linked-data/api/vocab#,canonical,prefixcc
 merged,APID.INTERACTIONS,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged,APIDB_PLASMODB,http://identifiers.org/plasmodb/,namespace_alias,bioregistry
 merged,apivc,http://purl.org/linked-data/api/vocab#,namespace_alias,prefixcc
+merged,apmwg,http://apmwg.ovh/,canonical,prefixcc
 merged,APO,http://purl.obolibrary.org/obo/APO_,canonical,obo
 merged,APO,http://bioregistry.io/APO:,prefix_alias,bioregistry
 merged,APO,http://www.ebi.ac.uk/ols/ontologies/apo/terms?iri=http://purl.obolibrary.org/obo/APO_,prefix_alias,bioregistry
@@ -1135,6 +1140,7 @@ merged,BIOMINDER,https://datalab.rwth-aachen.de/MINDER/resource/,prefix_alias,bi
 merged,BIOMINDER,https://identifiers.org/biominder/,prefix_alias,bioregistry
 merged,BIOMINDER,https://identifiers.org/biominder:,prefix_alias,bioregistry
 merged,BIOMINDER,https://n2t.net/biominder:,prefix_alias,bioregistry
+merged,biomodels,http://purl.obolibrary.org/obo/KISAO_,namespace_alias,prefixcc
 merged,BIOMODELS.DB,http://identifiers.org/biomodels.db/,canonical,bioregistry
 merged,BIOMODELS.DB,http://bio2rdf.org/biomodels:,prefix_alias,bioregistry
 merged,BIOMODELS.DB,http://biomodels.caltech.edu/,prefix_alias,bioregistry
@@ -1422,6 +1428,7 @@ merged,bn,http://babelnet.org/rdf/,canonical,prefixcc
 merged,bne,http://datos.bne.es/resource/,canonical,prefixcc
 merged,bner,http://datos.bne.es/resource/,namespace_alias,prefixcc
 merged,bnf,http://www.w3.org/2000/10/swap/grammar/bnf#,canonical,prefixcc
+merged,bng,https://w3id.org/dob/voc/epsg-27700#,canonical,prefixcc
 merged,bob,http://good.dad/meaning/bob#,canonical,prefixcc
 merged,BOLD.TAXONOMY,http://identifiers.org/bold.taxonomy/,canonical,bioregistry
 merged,BOLD.TAXONOMY,http://bio2rdf.org/bold:,prefix_alias,bioregistry
@@ -2406,6 +2413,7 @@ merged,CMPO,http://www.ebi.ac.uk/cmpo/CMPO_,canonical,bioregistry
 merged,CMPO,http://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged,CMPO,https://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged,CMPO,https://www.ebi.ac.uk/cmpo/CMPO_,prefix_alias,bioregistry
+merged,cmso,http://purls.helmholtz-metadaten.de/cmso/,canonical,prefixcc
 merged,cnt,http://www.w3.org/2011/content#,canonical,prefixcc
 merged,co,http://purl.org/ontology/co/core#,canonical,prefixcc
 merged,CO_320,https://cropontology.org/rdf/CO_320:,canonical,bioregistry
@@ -2812,6 +2820,7 @@ merged,CPT,http://www.aapc.com/codes/cpt-codes/,prefix_alias,bioregistry
 merged,CPT,https://bioregistry.io/ama-cpt:,prefix_alias,bioregistry
 merged,CPT,https://bioregistry.io/cpt:,prefix_alias,bioregistry
 merged,cpv,http://purl.org/weso/cpv/,canonical,prefixcc
+merged,cr,http://mlcommons.org/croissant/,canonical,prefixcc
 merged,CRAN,https://cran.r-project.org/web/packages/,canonical,bioregistry
 merged,CRAN,http://CRAN.R-project.org/package=,prefix_alias,bioregistry
 merged,CRAN,http://bioregistry.io/cran:,prefix_alias,bioregistry
@@ -2842,9 +2851,10 @@ merged,CRISPRDB,https://n2t.net/crisprdb:,prefix_alias,bioregistry
 merged,crm,http://www.cidoc-crm.org/cidoc-crm/,canonical,prefixcc
 merged,crmdig,http://www.ics.forth.gr/isl/CRMdig/,canonical,prefixcc
 merged,crmeh,http://purl.org/crmeh#,canonical,prefixcc
+merged,crmgeo,http://www.ics.forth.gr/isl/CRMgeo/,canonical,prefixcc
 merged,crminf,http://www.cidoc-crm.org/cidoc-crm/CRMinf/,canonical,prefixcc
 merged,crml,http://semweb.mmlab.be/ns/rml/condition#,canonical,prefixcc
-merged,crmsci,http://cidoc-crm.org/crmsci/,canonical,prefixcc
+merged,crmsci,http://www.cidoc-crm.org/extensions/crmsci/,canonical,prefixcc
 merged,CRO,http://purl.obolibrary.org/obo/CRO_,canonical,obo
 merged,CRO,http://bioregistry.io/CRO:,prefix_alias,bioregistry
 merged,CRO,http://www.ebi.ac.uk/ols/ontologies/cro/terms?iri=http://purl.obolibrary.org/obo/CRO_,prefix_alias,bioregistry
@@ -3542,6 +3552,7 @@ merged,DID,https://identifiers.org/DID:,prefix_alias,bioregistry
 merged,DID,https://identifiers.org/did/did:,prefix_alias,bioregistry
 merged,DID,https://n2t.net/did:,prefix_alias,bioregistry
 merged,DID,https://uniresolver.io/#did:,prefix_alias,bioregistry
+merged,did,https://w3id.org/dob/id/,prefix_alias,prefixcc
 merged,DIDEO,http://purl.obolibrary.org/obo/DIDEO_,canonical,obo
 merged,DIDEO,http://bioregistry.io/DIDEO:,prefix_alias,bioregistry
 merged,DIDEO,http://www.ebi.ac.uk/ols/ontologies/dideo/terms?iri=http://purl.obolibrary.org/obo/DIDEO_,prefix_alias,bioregistry
@@ -3648,6 +3659,7 @@ merged,doap,http://bioregistry.io/doap:,prefix_alias,bioregistry
 merged,doap,https://bioregistry.io/doap:,prefix_alias,bioregistry
 merged,doap,https://usefulinc.com/ns/doap#,prefix_alias,bioregistry
 merged,doas,http://deductions.github.io/doas.owl.ttl#,canonical,prefixcc
+merged,dob,https://w3id.org/dob/voc#,canonical,prefixcc
 merged,doc,http://www.w3.org/2000/10/swap/pim/doc#,canonical,prefixcc
 merged,docam,https://www.docam.ca/glossaurus/,canonical,prefixcc
 merged,docbook,http://docbook.org/ns/docbook/,canonical,prefixcc
@@ -3732,6 +3744,7 @@ merged,DOOR,https://identifiers.org/door/,prefix_alias,bioregistry
 merged,DOOR,https://identifiers.org/door:,prefix_alias,bioregistry
 merged,DOOR,https://n2t.net/door:,prefix_alias,bioregistry
 merged,door,http://kannel.open.ac.uk/ontology#,prefix_alias,prefixcc
+merged,dop,https://w3id.org/dob/voc/prop#,canonical,prefixcc
 merged,DOQCS.MODEL,http://identifiers.org/doqcs.model/,canonical,bioregistry
 merged,DOQCS.MODEL,http://bio2rdf.org/doqcs.model:,prefix_alias,bioregistry
 merged,DOQCS.MODEL,http://bioregistry.io/doqcs.model:,prefix_alias,bioregistry
@@ -4156,6 +4169,7 @@ merged,ecoll,http://purl.org/ceu/eco/1.0#,canonical,prefixcc
 merged,ecore,http://www.eclipse.org/emf/2002/Ecore#,canonical,prefixcc
 merged,ecos,http://purl.org/ecos#,canonical,prefixcc
 merged,ecowlim,http://ecowlim.tfri.gov.tw/lode/resource/,canonical,prefixcc
+merged,ecp,http://www.ebu.ch/metadata/ontologies/ebucoreplus#,canonical,prefixcc
 merged,ecpo,http://purl.org/ontology/ecpo#,canonical,prefixcc
 merged,ecrm,http://erlangen-crm.org/current/,canonical,prefixcc
 merged,ecs,http://rdf.ecs.soton.ac.uk/ontology/ecs#,canonical,prefixcc
@@ -4250,6 +4264,7 @@ merged,edgarcik,http://edgarwrap.ontologycentral.com/cik/,canonical,prefixcc
 merged,edm,http://www.europeana.eu/schemas/edm/,canonical,prefixcc
 merged,edo,http://semanticweb.org/edo#,canonical,prefixcc
 merged,edr,https://w3id.org/laas-iot/edr#,canonical,prefixcc
+merged,edtf,http://id.loc.gov/datatypes/EDTFScheme/,canonical,prefixcc
 merged,edu,https://schema.edu.ee/,canonical,prefixcc
 merged,edupro,http://ns.inria.fr/semed/eduprogression#,canonical,prefixcc
 merged,eem,http://purl.org/eem#,canonical,prefixcc
@@ -5598,7 +5613,7 @@ merged,GIARDIADB,https://giardiadb.org/giardiadb/showRecord.do?name=GeneRecordCl
 merged,GIARDIADB,https://identifiers.org/giardiadb/,prefix_alias,bioregistry
 merged,GIARDIADB,https://identifiers.org/giardiadb:,prefix_alias,bioregistry
 merged,GIARDIADB,https://n2t.net/giardiadb:,prefix_alias,bioregistry
-merged,gist,https://ontologies.semanticarts.com/o/gistCore#,canonical,prefixcc
+merged,gist,http://ontologies.semanticarts.com/gist#,canonical,prefixcc
 merged,GITHUB,http://identifiers.org/github/,canonical,bioregistry
 merged,GITHUB,http://bioregistry.io/github:,prefix_alias,bioregistry
 merged,GITHUB,http://github.com/,prefix_alias,bioregistry
@@ -5881,6 +5896,7 @@ merged,GO.RESOURCE,https://bioregistry.io/metaregistry/go/,canonical,bioregistry
 merged,GO.RESOURCE,http://bioregistry.io/go.resource:,prefix_alias,bioregistry
 merged,GO.RESOURCE,http://bioregistry.io/metaregistry/go/,prefix_alias,bioregistry
 merged,GO.RESOURCE,https://bioregistry.io/go.resource:,prefix_alias,bioregistry
+merged,GO_REF,http://purl.obolibrary.org/obo/go/references/,canonical,go
 merged,GOA,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged,goaf,http://goaf.fr/goaf#,canonical,prefixcc
 merged,goavoc,http://bio2rdf.org/goa_vocabulary:,canonical,prefixcc
@@ -6138,7 +6154,7 @@ merged,GRSDB,https://bioregistry.io/grsdb:,prefix_alias,bioregistry
 merged,GRSDB,https://identifiers.org/grsdb/,prefix_alias,bioregistry
 merged,GRSDB,https://identifiers.org/grsdb:,prefix_alias,bioregistry
 merged,GRSDB,https://n2t.net/grsdb:,prefix_alias,bioregistry
-merged,gs1,http://gs1.org/voc/,canonical,prefixcc
+merged,gs1,https://ref.gs1.org/voc/,canonical,prefixcc
 merged,gso,http://www.w3.org/2006/gen/ont#,canonical,prefixcc
 merged,gsp,http://www.opengis.net/ont/geosparql#,namespace_alias,prefixcc
 merged,GSSO,http://purl.obolibrary.org/obo/GSSO_,canonical,obo
@@ -7885,6 +7901,7 @@ merged,kpd,http://purl.org/kpd/,canonical,prefixcc
 merged,ksam,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged,ksamsok,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged,kupkb,http://www.e-lico.eu/data/kupkb/,canonical,prefixcc
+merged,kvasir,https://kvasir.discover.ilabt.imec.be/vocab#,canonical,prefixcc
 merged,kw,http://kwantu.net/kw/,canonical,prefixcc
 merged,kwijibo,http://kwijibo.talis.com/,canonical,prefixcc
 merged,l2sp,http://www.linked2safety-project.eu/properties/,canonical,prefixcc
@@ -8130,6 +8147,7 @@ merged,linkml,http://w3id.org/linkml/,prefix_alias,bioregistry
 merged,linkml,https://bioregistry.io/linkml:,prefix_alias,bioregistry
 merged,linkrel,https://www.w3.org/ns/iana/link-relations/relation#,namespace_alias,prefixcc
 merged,lio,http://purl.org/net/lio#,canonical,prefixcc
+merged,liph,https://gallosiciliani.unict.it/ns/lpont#,canonical,prefixcc
 merged,LIPID MAPS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged,LIPID_MAPS_CLASS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged,LIPID_MAPS_INSTANCE,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
@@ -8354,6 +8372,7 @@ merged,MAGGOT,https://identifiers.org/maggot:,prefix_alias,bioregistry
 merged,MAGGOT,https://pmb-bordeaux.fr/maggot/metadata/,prefix_alias,bioregistry
 merged,magmardl,http://www.semanticweb.org/magma-core/rdl#,canonical,prefixcc
 merged,magmauser,http://www.semanticweb.org/magma-core/user#,canonical,prefixcc
+merged,maid,https://mutual-aid.app/ns/core#,canonical,prefixcc
 merged,MAIZEGDB,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged,MAIZEGDB.LOCUS,http://bio2rdf.org/maizegdb:,prefix_alias,bioregistry
 merged,MAIZEGDB.LOCUS,http://bioregistry.io/MaizeGDB:,prefix_alias,bioregistry
@@ -8374,6 +8393,7 @@ merged,MAIZEGDB.LOCUS,https://www.maizegdb.org/data_center/gene_product?id=,pref
 merged,MAIZEGDB.LOCUS,https://www.maizegdb.org/gene_center/gene/,prefix_alias,bioregistry
 merged,MAIZEGDB.LOCUS,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged,MaizeGDB_Locus,http://identifiers.org/maizegdb.locus/,canonical,go
+merged,makeup,http://example.org/makeup#,canonical,prefixcc
 merged,malaka,http://george.gr/,canonical,prefixcc
 merged,malignneo,http://www.agfa.com/w3c/2009/malignantNeoplasm#,canonical,prefixcc
 merged,mammal,http://lod.taxonconcept.org/ontology/p01/Mammalia/index.owl#,canonical,prefixcc
@@ -8573,6 +8593,7 @@ merged,MEDLINEPLUS,https://identifiers.org/medlineplus:,prefix_alias,bioregistry
 merged,MEDLINEPLUS,https://n2t.net/medlineplus:,prefix_alias,bioregistry
 merged,MEDRA,http://identifiers.org/meddra/,namespace_alias,bioregistry
 merged,medred,http://w3id.org/medred/medred#,canonical,prefixcc
+merged,mee,http://www.w3.org/ns/pim/meeting#,canonical,prefixcc
 merged,meeting,http://www.w3.org/2002/07/meeting#,canonical,prefixcc
 merged,meetup,http://www.lotico.com/meetup/,canonical,prefixcc
 merged,mei,http://www.music-encoding.org/ns/mei/,canonical,prefixcc
@@ -9670,6 +9691,7 @@ merged,MZSPEC,https://identifiers.org/mzspec/mzspec:,prefix_alias,bioregistry
 merged,MZSPEC,https://n2t.net/mzspec:,prefix_alias,bioregistry
 merged,MZSPEC,https://proteomecentral.proteomexchange.org/usi/?usi=mzspec:,prefix_alias,bioregistry
 merged,MZSPEC,https://www.ebi.ac.uk/pride/archive/usi?usi=mzspec:,prefix_alias,bioregistry
+merged,nace2,http://data.europa.eu/ux2/nace2/,canonical,prefixcc
 merged,nalt,https://lod.nal.usda.gov/nalt/,canonical,prefixcc
 merged,name,http://example.org/name#,canonical,prefixcc
 merged,namespaces,https://vg.no/,canonical,prefixcc
@@ -11092,6 +11114,7 @@ merged,OPENWEMI,https://dcmi.github.io/openwemi/ns#,canonical,bioregistry
 merged,OPENWEMI,http://bioregistry.io/openwemi:,prefix_alias,bioregistry
 merged,OPENWEMI,http://dcmi.github.io/openwemi/ns#,prefix_alias,bioregistry
 merged,OPENWEMI,https://bioregistry.io/openwemi:,prefix_alias,bioregistry
+merged,openwemi,https://ns.dublincore.org/openwemi/,prefix_alias,prefixcc
 merged,oper,http://sweet.jpl.nasa.gov/2.0/mathOperation.owl#,canonical,prefixcc
 merged,OPL,http://purl.obolibrary.org/obo/OPL_,canonical,obo
 merged,OPL,http://bioregistry.io/OPL:,prefix_alias,bioregistry
@@ -11579,8 +11602,8 @@ merged,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein/,prefix_alias,bioregi
 merged,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein:,prefix_alias,bioregistry
 merged,PAXDB.PROTEIN,https://n2t.net/paxdb.protein:,prefix_alias,bioregistry
 merged,PAXDB.PROTEIN,https://pax-db.org/#!protein/,prefix_alias,bioregistry
-merged,pay,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
-merged,payment,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged,pay,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged,payment,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
 merged,PAZAR,http://identifiers.org/pazar/,canonical,bioregistry
 merged,PAZAR,http://bio2rdf.org/pazar:,prefix_alias,bioregistry
 merged,PAZAR,http://bioregistry.io/pazar:,prefix_alias,bioregistry
@@ -12245,7 +12268,7 @@ merged,PMDB,https://identifiers.org/pmdb:,prefix_alias,bioregistry
 merged,PMDB,https://mi.caspur.it/PMDB/user/search.php?idsearch=,prefix_alias,bioregistry
 merged,PMDB,https://n2t.net/pmdb:,prefix_alias,bioregistry
 merged,pmhb,http://pmhb.org/,canonical,prefixcc
-merged,PMID,http://identifiers.org/pubmed/,namespace_alias,bioregistry
+merged,PMID,http://identifiers.org/pubmed/,canonical,go
 merged,pml,http://provenanceweb.org/ns/pml#,canonical,prefixcc
 merged,pmlj,http://inference-web.org/2.0/pml-justification.owl#,canonical,prefixcc
 merged,pmlp,http://inference-web.org/2.0/pml-provenance.owl#,canonical,prefixcc
@@ -12661,6 +12684,7 @@ merged,PSIPAR,https://identifiers.org/psipar:,prefix_alias,bioregistry
 merged,PSIPAR,https://n2t.net/psipar:,prefix_alias,bioregistry
 merged,PSIPAR,https://www.ebi.ac.uk/ontology-lookup/?termId=PAR:,prefix_alias,bioregistry
 merged,psm,https://paul.ti.rw.fau.de/~jo00defe/ont/psm#,canonical,prefixcc
+merged,psn,https://purl.org/psn/vocab#,canonical,prefixcc
 merged,PSO,http://purl.obolibrary.org/obo/PSO_,canonical,obo
 merged,PSO,http://bioregistry.io/PSO:,prefix_alias,bioregistry
 merged,PSO,http://www.ebi.ac.uk/ols/ontologies/pso/terms?iri=http://purl.obolibrary.org/obo/PSO_,prefix_alias,bioregistry
@@ -12768,7 +12792,6 @@ merged,PUBLONS.RESEARCHER,https://publons.com/researcher/,canonical,bioregistry
 merged,PUBLONS.RESEARCHER,http://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
 merged,PUBLONS.RESEARCHER,http://publons.com/researcher/,prefix_alias,bioregistry
 merged,PUBLONS.RESEARCHER,https://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
-merged,PUBMED,http://identifiers.org/pubmed/,canonical,bioregistry
 merged,PUBMED,http://bio2rdf.org/pubmed:,prefix_alias,bioregistry
 merged,PUBMED,http://bioregistry.io/MEDLINE:,prefix_alias,bioregistry
 merged,PUBMED,http://bioregistry.io/PMID:,prefix_alias,bioregistry
@@ -12801,6 +12824,7 @@ merged,PUBMED,https://scholia.toolforge.org/pubmed/,prefix_alias,bioregistry
 merged,PUBMED,https://www.hubmed.org/display.cgi?uids=,prefix_alias,bioregistry
 merged,PUBMED,https://www.ncbi.nlm.nih.gov/pubmed/,prefix_alias,bioregistry
 merged,pubmed,http://bio2rdf.org/pubmed_vocabulary:,prefix_alias,prefixcc
+merged,PUBMED,http://identifiers.org/pubmed/,namespace_alias,bioregistry
 merged,puc,http://purl.org/NET/puc#,canonical,prefixcc
 merged,puelia,http://kwijibo.talis.com/vocabs/puelia#,canonical,prefixcc
 merged,puml,http://plantuml.com/ontology#,canonical,prefixcc
@@ -13121,6 +13145,7 @@ merged,RDFA,https://www.w3.org/ns/rdfa#,prefix_alias,bioregistry
 merged,rdfdata,http://rdf.data-vocabulary.org/rdf.xml#,canonical,prefixcc
 merged,rdfdf,http://www.openlinksw.com/virtrdf-data-formats#,canonical,prefixcc
 merged,rdfg,http://www.w3.org/2004/03/trix/rdfg-1/,canonical,prefixcc
+merged,rdfl,https://w3id.org/rdf-lens/ontology#,canonical,prefixcc
 merged,rdfp,https://w3id.org/rdfp/,canonical,prefixcc
 merged,rdfs,http://www.w3.org/2000/01/rdf-schema#,canonical,linkml
 merged,rdfs,http://bioregistry.io/rdfs:,prefix_alias,bioregistry
@@ -13754,6 +13779,7 @@ merged,schema,http://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged,schema,https://bioregistry.io/schema:,prefix_alias,bioregistry
 merged,schema,https://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged,schemaorg,https://schema.org/,namespace_alias,bioregistry
+merged,schemas,https://schema.org/,namespace_alias,prefixcc
 merged,scho,http://www.scholarlydata.org/ontology/conference-ontology.owl#,canonical,prefixcc
 merged,schoi,https://w3id.org/scholarlydata/ontology/indicators-ontology.owl#,canonical,prefixcc
 merged,SCHOLIA.RESOURCE,https://bioregistry.io/metaregistry/scholia/,canonical,bioregistry
@@ -15147,6 +15173,7 @@ merged,test2,http://this.invalid/test2#,canonical,prefixcc
 merged,text,http://jena.apache.org/text#,canonical,prefixcc
 merged,textgrid,https://textgridrep.org/,canonical,prefixcc
 merged,tg,https://triplydb.com/Triply/tg/def/,canonical,prefixcc
+merged,tgc,http://www.hds.utc.fr/tg#,canonical,prefixcc
 merged,TGD,http://identifiers.org/tgd/,canonical,go
 merged,TGD,http://bio2rdf.org/tgd:,prefix_alias,bioregistry
 merged,TGD,http://bioregistry.io/tgd:,prefix_alias,bioregistry
@@ -15267,6 +15294,7 @@ merged,TOPDB,https://n2t.net/topdb:,prefix_alias,bioregistry
 merged,TOPDB,https://topdb.enzim.hu/?m=show&id=,prefix_alias,bioregistry
 merged,TOPFIND,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged,topo,http://data.ign.fr/def/topo#,canonical,prefixcc
+merged,tops,http://www.topbraid.org/tops#,canonical,prefixcc
 merged,tosh,http://topbraid.org/tosh#,canonical,prefixcc
 merged,TOXOPLASMA,http://identifiers.org/toxoplasma/,canonical,bioregistry
 merged,TOXOPLASMA,http://bioregistry.io/toxoplasma:,prefix_alias,bioregistry
@@ -15331,6 +15359,7 @@ merged,TREEFAM,https://identifiers.org/treefam:,prefix_alias,bioregistry
 merged,TREEFAM,https://n2t.net/treefam:,prefix_alias,bioregistry
 merged,TREEFAM,https://www.treefam.org/cgi-bin/TFinfo.pl?ac=,prefix_alias,bioregistry
 merged,TREEFAM,https://www.treefam.org/family/,prefix_alias,bioregistry
+merged,TreeGrafter,http://identifiers.org/panther.family/,namespace_alias,go
 merged,trek,https://w3id.org/trek/,canonical,prefixcc
 merged,TRICDB,http://identifiers.org/tricdb/,canonical,bioregistry
 merged,TRICDB,http://biomeddb.org/Disease/Details?DISEASEID=,prefix_alias,bioregistry
@@ -16081,6 +16110,7 @@ merged,va,http://code-research.eu/ontology/visual-analytics#,canonical,prefixcc
 merged,vacseen1,http://www.semanticweb.org/parthasb/ontologies/2014/6/vacseen1/,canonical,prefixcc
 merged,vaem,http://www.linkedmodel.org/schema/vaem#,canonical,prefixcc
 merged,vag,http://www.essepuntato.it/2013/10/vagueness/,canonical,prefixcc
+merged,vair,https://w3id.org/vair#,canonical,prefixcc
 merged,VALIDATORDB,http://identifiers.org/pdb/,namespace_alias,bioregistry
 merged,value,http://gfgfd.vs/,canonical,prefixcc
 merged,valueflows,https://w3id.org/valueflows/,canonical,prefixcc

--- a/src/prefixmaps/data/merged.monarch.csv
+++ b/src/prefixmaps/data/merged.monarch.csv
@@ -185,6 +185,7 @@ merged.monarch,AfPO,http://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged.monarch,AfPO,https://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged.monarch,AfPO,https://purl.obolibrary.org/obo/AfPO_,prefix_alias,bioregistry
 merged.monarch,afr,http://purl.allotrope.org/ontologies/result#,canonical,prefixcc
+merged.monarch,after,http://rds.posccaesar.org/ontology/plm/ds/,canonical,prefixcc
 merged.monarch,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy/,canonical,bioregistry
 merged.monarch,AFTOL.TAXONOMY,http://bioregistry.io/aftol.taxonomy:,prefix_alias,bioregistry
 merged.monarch,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy:,prefix_alias,bioregistry
@@ -251,7 +252,9 @@ merged.monarch,AIO,https://w3id.org/aio/,canonical,bioregistry
 merged.monarch,AIO,http://bioregistry.io/aio:,prefix_alias,bioregistry
 merged.monarch,AIO,http://w3id.org/aio/,prefix_alias,bioregistry
 merged.monarch,AIO,https://bioregistry.io/aio:,prefix_alias,bioregistry
+merged.monarch,aio,https://paul.ti.rw.fau.de/~jo00defe/SemWoT/aio#,prefix_alias,prefixcc
 merged.monarch,air,http://dig.csail.mit.edu/TAMI/2007/amord/air#,canonical,prefixcc
+merged.monarch,airo,https://w3id.org/airo#,canonical,prefixcc
 merged.monarch,airport,http://www.daml.org/2001/10/html/airport-ont#,canonical,prefixcc
 merged.monarch,airs,https://raw.githubusercontent.com/airs-linked-data/lov/latest/src/airs_vocabulary.ttl#,canonical,prefixcc
 merged.monarch,AISM,http://purl.obolibrary.org/obo/AISM_,canonical,obo
@@ -319,6 +322,7 @@ merged.monarch,AMPHX,https://www.ebi.ac.uk/ols/ontologies/amphx/terms?iri=http:/
 merged.monarch,ams,http://data.amadeus.com/,canonical,prefixcc
 merged.monarch,amsl,http://vocab.ub.uni-leipzig.de/amsl/,canonical,prefixcc
 merged.monarch,amt,http://academic-meta-tool.xyz/vocab#,canonical,prefixcc
+merged.monarch,amv,https://w3id.org/amv/,canonical,prefixcc
 merged.monarch,anca,http://users.utcluj.ro/~raluca/rdf_ontologies_ralu/ralu_modified_ontology_pizzas2_0#,canonical,prefixcc
 merged.monarch,aneo,http://akonadi-project.org/ontologies/aneo#,canonical,prefixcc
 merged.monarch,ann,http://www.w3.org/2000/10/annotation-ns#,canonical,prefixcc
@@ -422,6 +426,7 @@ merged.monarch,api,http://purl.org/linked-data/api/vocab#,canonical,prefixcc
 merged.monarch,APID.INTERACTIONS,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.monarch,APIDB_PLASMODB,http://identifiers.org/plasmodb/,namespace_alias,bioregistry
 merged.monarch,apivc,http://purl.org/linked-data/api/vocab#,namespace_alias,prefixcc
+merged.monarch,apmwg,http://apmwg.ovh/,canonical,prefixcc
 merged.monarch,APO,http://purl.obolibrary.org/obo/APO_,canonical,obo
 merged.monarch,APO,http://bioregistry.io/APO:,prefix_alias,bioregistry
 merged.monarch,APO,http://www.ebi.ac.uk/ols/ontologies/apo/terms?iri=http://purl.obolibrary.org/obo/APO_,prefix_alias,bioregistry
@@ -1135,6 +1140,7 @@ merged.monarch,BIOMINDER,https://datalab.rwth-aachen.de/MINDER/resource/,prefix_
 merged.monarch,BIOMINDER,https://identifiers.org/biominder/,prefix_alias,bioregistry
 merged.monarch,BIOMINDER,https://identifiers.org/biominder:,prefix_alias,bioregistry
 merged.monarch,BIOMINDER,https://n2t.net/biominder:,prefix_alias,bioregistry
+merged.monarch,biomodels,http://purl.obolibrary.org/obo/KISAO_,namespace_alias,prefixcc
 merged.monarch,BIOMODELS.DB,http://identifiers.org/biomodels.db/,canonical,bioregistry
 merged.monarch,BIOMODELS.DB,http://bio2rdf.org/biomodels:,prefix_alias,bioregistry
 merged.monarch,BIOMODELS.DB,http://biomodels.caltech.edu/,prefix_alias,bioregistry
@@ -1422,6 +1428,7 @@ merged.monarch,bn,http://babelnet.org/rdf/,canonical,prefixcc
 merged.monarch,bne,http://datos.bne.es/resource/,canonical,prefixcc
 merged.monarch,bner,http://datos.bne.es/resource/,namespace_alias,prefixcc
 merged.monarch,bnf,http://www.w3.org/2000/10/swap/grammar/bnf#,canonical,prefixcc
+merged.monarch,bng,https://w3id.org/dob/voc/epsg-27700#,canonical,prefixcc
 merged.monarch,bob,http://good.dad/meaning/bob#,canonical,prefixcc
 merged.monarch,BOLD.TAXONOMY,http://identifiers.org/bold.taxonomy/,canonical,bioregistry
 merged.monarch,BOLD.TAXONOMY,http://bio2rdf.org/bold:,prefix_alias,bioregistry
@@ -2406,6 +2413,7 @@ merged.monarch,CMPO,http://www.ebi.ac.uk/cmpo/CMPO_,canonical,bioregistry
 merged.monarch,CMPO,http://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged.monarch,CMPO,https://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged.monarch,CMPO,https://www.ebi.ac.uk/cmpo/CMPO_,prefix_alias,bioregistry
+merged.monarch,cmso,http://purls.helmholtz-metadaten.de/cmso/,canonical,prefixcc
 merged.monarch,cnt,http://www.w3.org/2011/content#,canonical,prefixcc
 merged.monarch,co,http://purl.org/ontology/co/core#,canonical,prefixcc
 merged.monarch,CO_320,https://cropontology.org/rdf/CO_320:,canonical,bioregistry
@@ -2812,6 +2820,7 @@ merged.monarch,CPT,http://www.aapc.com/codes/cpt-codes/,prefix_alias,bioregistry
 merged.monarch,CPT,https://bioregistry.io/ama-cpt:,prefix_alias,bioregistry
 merged.monarch,CPT,https://bioregistry.io/cpt:,prefix_alias,bioregistry
 merged.monarch,cpv,http://purl.org/weso/cpv/,canonical,prefixcc
+merged.monarch,cr,http://mlcommons.org/croissant/,canonical,prefixcc
 merged.monarch,CRAN,https://cran.r-project.org/web/packages/,canonical,bioregistry
 merged.monarch,CRAN,http://CRAN.R-project.org/package=,prefix_alias,bioregistry
 merged.monarch,CRAN,http://bioregistry.io/cran:,prefix_alias,bioregistry
@@ -2842,9 +2851,10 @@ merged.monarch,CRISPRDB,https://n2t.net/crisprdb:,prefix_alias,bioregistry
 merged.monarch,crm,http://www.cidoc-crm.org/cidoc-crm/,canonical,prefixcc
 merged.monarch,crmdig,http://www.ics.forth.gr/isl/CRMdig/,canonical,prefixcc
 merged.monarch,crmeh,http://purl.org/crmeh#,canonical,prefixcc
+merged.monarch,crmgeo,http://www.ics.forth.gr/isl/CRMgeo/,canonical,prefixcc
 merged.monarch,crminf,http://www.cidoc-crm.org/cidoc-crm/CRMinf/,canonical,prefixcc
 merged.monarch,crml,http://semweb.mmlab.be/ns/rml/condition#,canonical,prefixcc
-merged.monarch,crmsci,http://cidoc-crm.org/crmsci/,canonical,prefixcc
+merged.monarch,crmsci,http://www.cidoc-crm.org/extensions/crmsci/,canonical,prefixcc
 merged.monarch,CRO,http://purl.obolibrary.org/obo/CRO_,canonical,obo
 merged.monarch,CRO,http://bioregistry.io/CRO:,prefix_alias,bioregistry
 merged.monarch,CRO,http://www.ebi.ac.uk/ols/ontologies/cro/terms?iri=http://purl.obolibrary.org/obo/CRO_,prefix_alias,bioregistry
@@ -3542,6 +3552,7 @@ merged.monarch,DID,https://identifiers.org/DID:,prefix_alias,bioregistry
 merged.monarch,DID,https://identifiers.org/did/did:,prefix_alias,bioregistry
 merged.monarch,DID,https://n2t.net/did:,prefix_alias,bioregistry
 merged.monarch,DID,https://uniresolver.io/#did:,prefix_alias,bioregistry
+merged.monarch,did,https://w3id.org/dob/id/,prefix_alias,prefixcc
 merged.monarch,DIDEO,http://purl.obolibrary.org/obo/DIDEO_,canonical,obo
 merged.monarch,DIDEO,http://bioregistry.io/DIDEO:,prefix_alias,bioregistry
 merged.monarch,DIDEO,http://www.ebi.ac.uk/ols/ontologies/dideo/terms?iri=http://purl.obolibrary.org/obo/DIDEO_,prefix_alias,bioregistry
@@ -3648,6 +3659,7 @@ merged.monarch,doap,http://bioregistry.io/doap:,prefix_alias,bioregistry
 merged.monarch,doap,https://bioregistry.io/doap:,prefix_alias,bioregistry
 merged.monarch,doap,https://usefulinc.com/ns/doap#,prefix_alias,bioregistry
 merged.monarch,doas,http://deductions.github.io/doas.owl.ttl#,canonical,prefixcc
+merged.monarch,dob,https://w3id.org/dob/voc#,canonical,prefixcc
 merged.monarch,doc,http://www.w3.org/2000/10/swap/pim/doc#,canonical,prefixcc
 merged.monarch,docam,https://www.docam.ca/glossaurus/,canonical,prefixcc
 merged.monarch,docbook,http://docbook.org/ns/docbook/,canonical,prefixcc
@@ -3732,6 +3744,7 @@ merged.monarch,DOOR,https://identifiers.org/door/,prefix_alias,bioregistry
 merged.monarch,DOOR,https://identifiers.org/door:,prefix_alias,bioregistry
 merged.monarch,DOOR,https://n2t.net/door:,prefix_alias,bioregistry
 merged.monarch,door,http://kannel.open.ac.uk/ontology#,prefix_alias,prefixcc
+merged.monarch,dop,https://w3id.org/dob/voc/prop#,canonical,prefixcc
 merged.monarch,DOQCS.MODEL,http://identifiers.org/doqcs.model/,canonical,bioregistry
 merged.monarch,DOQCS.MODEL,http://bio2rdf.org/doqcs.model:,prefix_alias,bioregistry
 merged.monarch,DOQCS.MODEL,http://bioregistry.io/doqcs.model:,prefix_alias,bioregistry
@@ -4156,6 +4169,7 @@ merged.monarch,ecoll,http://purl.org/ceu/eco/1.0#,canonical,prefixcc
 merged.monarch,ecore,http://www.eclipse.org/emf/2002/Ecore#,canonical,prefixcc
 merged.monarch,ecos,http://purl.org/ecos#,canonical,prefixcc
 merged.monarch,ecowlim,http://ecowlim.tfri.gov.tw/lode/resource/,canonical,prefixcc
+merged.monarch,ecp,http://www.ebu.ch/metadata/ontologies/ebucoreplus#,canonical,prefixcc
 merged.monarch,ecpo,http://purl.org/ontology/ecpo#,canonical,prefixcc
 merged.monarch,ecrm,http://erlangen-crm.org/current/,canonical,prefixcc
 merged.monarch,ecs,http://rdf.ecs.soton.ac.uk/ontology/ecs#,canonical,prefixcc
@@ -4250,6 +4264,7 @@ merged.monarch,edgarcik,http://edgarwrap.ontologycentral.com/cik/,canonical,pref
 merged.monarch,edm,http://www.europeana.eu/schemas/edm/,canonical,prefixcc
 merged.monarch,edo,http://semanticweb.org/edo#,canonical,prefixcc
 merged.monarch,edr,https://w3id.org/laas-iot/edr#,canonical,prefixcc
+merged.monarch,edtf,http://id.loc.gov/datatypes/EDTFScheme/,canonical,prefixcc
 merged.monarch,edu,https://schema.edu.ee/,canonical,prefixcc
 merged.monarch,edupro,http://ns.inria.fr/semed/eduprogression#,canonical,prefixcc
 merged.monarch,eem,http://purl.org/eem#,canonical,prefixcc
@@ -5598,7 +5613,7 @@ merged.monarch,GIARDIADB,https://giardiadb.org/giardiadb/showRecord.do?name=Gene
 merged.monarch,GIARDIADB,https://identifiers.org/giardiadb/,prefix_alias,bioregistry
 merged.monarch,GIARDIADB,https://identifiers.org/giardiadb:,prefix_alias,bioregistry
 merged.monarch,GIARDIADB,https://n2t.net/giardiadb:,prefix_alias,bioregistry
-merged.monarch,gist,https://ontologies.semanticarts.com/o/gistCore#,canonical,prefixcc
+merged.monarch,gist,http://ontologies.semanticarts.com/gist#,canonical,prefixcc
 merged.monarch,GITHUB,http://identifiers.org/github/,canonical,bioregistry
 merged.monarch,GITHUB,http://bioregistry.io/github:,prefix_alias,bioregistry
 merged.monarch,GITHUB,http://github.com/,prefix_alias,bioregistry
@@ -5881,6 +5896,7 @@ merged.monarch,GO.RESOURCE,https://bioregistry.io/metaregistry/go/,canonical,bio
 merged.monarch,GO.RESOURCE,http://bioregistry.io/go.resource:,prefix_alias,bioregistry
 merged.monarch,GO.RESOURCE,http://bioregistry.io/metaregistry/go/,prefix_alias,bioregistry
 merged.monarch,GO.RESOURCE,https://bioregistry.io/go.resource:,prefix_alias,bioregistry
+merged.monarch,GO_REF,http://purl.obolibrary.org/obo/go/references/,canonical,go
 merged.monarch,GOA,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.monarch,goaf,http://goaf.fr/goaf#,canonical,prefixcc
 merged.monarch,goavoc,http://bio2rdf.org/goa_vocabulary:,canonical,prefixcc
@@ -6138,7 +6154,7 @@ merged.monarch,GRSDB,https://bioregistry.io/grsdb:,prefix_alias,bioregistry
 merged.monarch,GRSDB,https://identifiers.org/grsdb/,prefix_alias,bioregistry
 merged.monarch,GRSDB,https://identifiers.org/grsdb:,prefix_alias,bioregistry
 merged.monarch,GRSDB,https://n2t.net/grsdb:,prefix_alias,bioregistry
-merged.monarch,gs1,http://gs1.org/voc/,canonical,prefixcc
+merged.monarch,gs1,https://ref.gs1.org/voc/,canonical,prefixcc
 merged.monarch,gso,http://www.w3.org/2006/gen/ont#,canonical,prefixcc
 merged.monarch,gsp,http://www.opengis.net/ont/geosparql#,namespace_alias,prefixcc
 merged.monarch,GSSO,http://purl.obolibrary.org/obo/GSSO_,canonical,obo
@@ -7885,6 +7901,7 @@ merged.monarch,kpd,http://purl.org/kpd/,canonical,prefixcc
 merged.monarch,ksam,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged.monarch,ksamsok,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged.monarch,kupkb,http://www.e-lico.eu/data/kupkb/,canonical,prefixcc
+merged.monarch,kvasir,https://kvasir.discover.ilabt.imec.be/vocab#,canonical,prefixcc
 merged.monarch,kw,http://kwantu.net/kw/,canonical,prefixcc
 merged.monarch,kwijibo,http://kwijibo.talis.com/,canonical,prefixcc
 merged.monarch,l2sp,http://www.linked2safety-project.eu/properties/,canonical,prefixcc
@@ -8130,6 +8147,7 @@ merged.monarch,linkml,http://w3id.org/linkml/,prefix_alias,bioregistry
 merged.monarch,linkml,https://bioregistry.io/linkml:,prefix_alias,bioregistry
 merged.monarch,linkrel,https://www.w3.org/ns/iana/link-relations/relation#,namespace_alias,prefixcc
 merged.monarch,lio,http://purl.org/net/lio#,canonical,prefixcc
+merged.monarch,liph,https://gallosiciliani.unict.it/ns/lpont#,canonical,prefixcc
 merged.monarch,LIPID MAPS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged.monarch,LIPID_MAPS_CLASS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged.monarch,LIPID_MAPS_INSTANCE,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
@@ -8354,6 +8372,7 @@ merged.monarch,MAGGOT,https://identifiers.org/maggot:,prefix_alias,bioregistry
 merged.monarch,MAGGOT,https://pmb-bordeaux.fr/maggot/metadata/,prefix_alias,bioregistry
 merged.monarch,magmardl,http://www.semanticweb.org/magma-core/rdl#,canonical,prefixcc
 merged.monarch,magmauser,http://www.semanticweb.org/magma-core/user#,canonical,prefixcc
+merged.monarch,maid,https://mutual-aid.app/ns/core#,canonical,prefixcc
 merged.monarch,MAIZEGDB,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged.monarch,MAIZEGDB.LOCUS,http://bio2rdf.org/maizegdb:,prefix_alias,bioregistry
 merged.monarch,MAIZEGDB.LOCUS,http://bioregistry.io/MaizeGDB:,prefix_alias,bioregistry
@@ -8374,6 +8393,7 @@ merged.monarch,MAIZEGDB.LOCUS,https://www.maizegdb.org/data_center/gene_product?
 merged.monarch,MAIZEGDB.LOCUS,https://www.maizegdb.org/gene_center/gene/,prefix_alias,bioregistry
 merged.monarch,MAIZEGDB.LOCUS,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged.monarch,MaizeGDB_Locus,http://identifiers.org/maizegdb.locus/,canonical,go
+merged.monarch,makeup,http://example.org/makeup#,canonical,prefixcc
 merged.monarch,malaka,http://george.gr/,canonical,prefixcc
 merged.monarch,malignneo,http://www.agfa.com/w3c/2009/malignantNeoplasm#,canonical,prefixcc
 merged.monarch,mammal,http://lod.taxonconcept.org/ontology/p01/Mammalia/index.owl#,canonical,prefixcc
@@ -8573,6 +8593,7 @@ merged.monarch,MEDLINEPLUS,https://identifiers.org/medlineplus:,prefix_alias,bio
 merged.monarch,MEDLINEPLUS,https://n2t.net/medlineplus:,prefix_alias,bioregistry
 merged.monarch,MEDRA,http://identifiers.org/meddra/,namespace_alias,bioregistry
 merged.monarch,medred,http://w3id.org/medred/medred#,canonical,prefixcc
+merged.monarch,mee,http://www.w3.org/ns/pim/meeting#,canonical,prefixcc
 merged.monarch,meeting,http://www.w3.org/2002/07/meeting#,canonical,prefixcc
 merged.monarch,meetup,http://www.lotico.com/meetup/,canonical,prefixcc
 merged.monarch,mei,http://www.music-encoding.org/ns/mei/,canonical,prefixcc
@@ -9670,6 +9691,7 @@ merged.monarch,MZSPEC,https://identifiers.org/mzspec/mzspec:,prefix_alias,bioreg
 merged.monarch,MZSPEC,https://n2t.net/mzspec:,prefix_alias,bioregistry
 merged.monarch,MZSPEC,https://proteomecentral.proteomexchange.org/usi/?usi=mzspec:,prefix_alias,bioregistry
 merged.monarch,MZSPEC,https://www.ebi.ac.uk/pride/archive/usi?usi=mzspec:,prefix_alias,bioregistry
+merged.monarch,nace2,http://data.europa.eu/ux2/nace2/,canonical,prefixcc
 merged.monarch,nalt,https://lod.nal.usda.gov/nalt/,canonical,prefixcc
 merged.monarch,name,http://example.org/name#,canonical,prefixcc
 merged.monarch,namespaces,https://vg.no/,canonical,prefixcc
@@ -11092,6 +11114,7 @@ merged.monarch,OPENWEMI,https://dcmi.github.io/openwemi/ns#,canonical,bioregistr
 merged.monarch,OPENWEMI,http://bioregistry.io/openwemi:,prefix_alias,bioregistry
 merged.monarch,OPENWEMI,http://dcmi.github.io/openwemi/ns#,prefix_alias,bioregistry
 merged.monarch,OPENWEMI,https://bioregistry.io/openwemi:,prefix_alias,bioregistry
+merged.monarch,openwemi,https://ns.dublincore.org/openwemi/,prefix_alias,prefixcc
 merged.monarch,oper,http://sweet.jpl.nasa.gov/2.0/mathOperation.owl#,canonical,prefixcc
 merged.monarch,OPL,http://purl.obolibrary.org/obo/OPL_,canonical,obo
 merged.monarch,OPL,http://bioregistry.io/OPL:,prefix_alias,bioregistry
@@ -11579,8 +11602,8 @@ merged.monarch,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein/,prefix_alias
 merged.monarch,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein:,prefix_alias,bioregistry
 merged.monarch,PAXDB.PROTEIN,https://n2t.net/paxdb.protein:,prefix_alias,bioregistry
 merged.monarch,PAXDB.PROTEIN,https://pax-db.org/#!protein/,prefix_alias,bioregistry
-merged.monarch,pay,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
-merged.monarch,payment,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged.monarch,pay,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged.monarch,payment,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
 merged.monarch,PAZAR,http://identifiers.org/pazar/,canonical,bioregistry
 merged.monarch,PAZAR,http://bio2rdf.org/pazar:,prefix_alias,bioregistry
 merged.monarch,PAZAR,http://bioregistry.io/pazar:,prefix_alias,bioregistry
@@ -12245,7 +12268,7 @@ merged.monarch,PMDB,https://identifiers.org/pmdb:,prefix_alias,bioregistry
 merged.monarch,PMDB,https://mi.caspur.it/PMDB/user/search.php?idsearch=,prefix_alias,bioregistry
 merged.monarch,PMDB,https://n2t.net/pmdb:,prefix_alias,bioregistry
 merged.monarch,pmhb,http://pmhb.org/,canonical,prefixcc
-merged.monarch,PMID,http://identifiers.org/pubmed/,namespace_alias,bioregistry
+merged.monarch,PMID,http://identifiers.org/pubmed/,canonical,go
 merged.monarch,pml,http://provenanceweb.org/ns/pml#,canonical,prefixcc
 merged.monarch,pmlj,http://inference-web.org/2.0/pml-justification.owl#,canonical,prefixcc
 merged.monarch,pmlp,http://inference-web.org/2.0/pml-provenance.owl#,canonical,prefixcc
@@ -12661,6 +12684,7 @@ merged.monarch,PSIPAR,https://identifiers.org/psipar:,prefix_alias,bioregistry
 merged.monarch,PSIPAR,https://n2t.net/psipar:,prefix_alias,bioregistry
 merged.monarch,PSIPAR,https://www.ebi.ac.uk/ontology-lookup/?termId=PAR:,prefix_alias,bioregistry
 merged.monarch,psm,https://paul.ti.rw.fau.de/~jo00defe/ont/psm#,canonical,prefixcc
+merged.monarch,psn,https://purl.org/psn/vocab#,canonical,prefixcc
 merged.monarch,PSO,http://purl.obolibrary.org/obo/PSO_,canonical,obo
 merged.monarch,PSO,http://bioregistry.io/PSO:,prefix_alias,bioregistry
 merged.monarch,PSO,http://www.ebi.ac.uk/ols/ontologies/pso/terms?iri=http://purl.obolibrary.org/obo/PSO_,prefix_alias,bioregistry
@@ -12768,7 +12792,6 @@ merged.monarch,PUBLONS.RESEARCHER,https://publons.com/researcher/,canonical,bior
 merged.monarch,PUBLONS.RESEARCHER,http://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
 merged.monarch,PUBLONS.RESEARCHER,http://publons.com/researcher/,prefix_alias,bioregistry
 merged.monarch,PUBLONS.RESEARCHER,https://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
-merged.monarch,PUBMED,http://identifiers.org/pubmed/,canonical,bioregistry
 merged.monarch,PUBMED,http://bio2rdf.org/pubmed:,prefix_alias,bioregistry
 merged.monarch,PUBMED,http://bioregistry.io/MEDLINE:,prefix_alias,bioregistry
 merged.monarch,PUBMED,http://bioregistry.io/PMID:,prefix_alias,bioregistry
@@ -12801,6 +12824,7 @@ merged.monarch,PUBMED,https://scholia.toolforge.org/pubmed/,prefix_alias,bioregi
 merged.monarch,PUBMED,https://www.hubmed.org/display.cgi?uids=,prefix_alias,bioregistry
 merged.monarch,PUBMED,https://www.ncbi.nlm.nih.gov/pubmed/,prefix_alias,bioregistry
 merged.monarch,pubmed,http://bio2rdf.org/pubmed_vocabulary:,prefix_alias,prefixcc
+merged.monarch,PUBMED,http://identifiers.org/pubmed/,namespace_alias,bioregistry
 merged.monarch,puc,http://purl.org/NET/puc#,canonical,prefixcc
 merged.monarch,puelia,http://kwijibo.talis.com/vocabs/puelia#,canonical,prefixcc
 merged.monarch,puml,http://plantuml.com/ontology#,canonical,prefixcc
@@ -13121,6 +13145,7 @@ merged.monarch,RDFA,https://www.w3.org/ns/rdfa#,prefix_alias,bioregistry
 merged.monarch,rdfdata,http://rdf.data-vocabulary.org/rdf.xml#,canonical,prefixcc
 merged.monarch,rdfdf,http://www.openlinksw.com/virtrdf-data-formats#,canonical,prefixcc
 merged.monarch,rdfg,http://www.w3.org/2004/03/trix/rdfg-1/,canonical,prefixcc
+merged.monarch,rdfl,https://w3id.org/rdf-lens/ontology#,canonical,prefixcc
 merged.monarch,rdfp,https://w3id.org/rdfp/,canonical,prefixcc
 merged.monarch,rdfs,http://www.w3.org/2000/01/rdf-schema#,canonical,linkml
 merged.monarch,rdfs,http://bioregistry.io/rdfs:,prefix_alias,bioregistry
@@ -13754,6 +13779,7 @@ merged.monarch,schema,http://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged.monarch,schema,https://bioregistry.io/schema:,prefix_alias,bioregistry
 merged.monarch,schema,https://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged.monarch,schemaorg,https://schema.org/,namespace_alias,bioregistry
+merged.monarch,schemas,https://schema.org/,namespace_alias,prefixcc
 merged.monarch,scho,http://www.scholarlydata.org/ontology/conference-ontology.owl#,canonical,prefixcc
 merged.monarch,schoi,https://w3id.org/scholarlydata/ontology/indicators-ontology.owl#,canonical,prefixcc
 merged.monarch,SCHOLIA.RESOURCE,https://bioregistry.io/metaregistry/scholia/,canonical,bioregistry
@@ -15147,6 +15173,7 @@ merged.monarch,test2,http://this.invalid/test2#,canonical,prefixcc
 merged.monarch,text,http://jena.apache.org/text#,canonical,prefixcc
 merged.monarch,textgrid,https://textgridrep.org/,canonical,prefixcc
 merged.monarch,tg,https://triplydb.com/Triply/tg/def/,canonical,prefixcc
+merged.monarch,tgc,http://www.hds.utc.fr/tg#,canonical,prefixcc
 merged.monarch,TGD,http://identifiers.org/tgd/,canonical,go
 merged.monarch,TGD,http://bio2rdf.org/tgd:,prefix_alias,bioregistry
 merged.monarch,TGD,http://bioregistry.io/tgd:,prefix_alias,bioregistry
@@ -15267,6 +15294,7 @@ merged.monarch,TOPDB,https://n2t.net/topdb:,prefix_alias,bioregistry
 merged.monarch,TOPDB,https://topdb.enzim.hu/?m=show&id=,prefix_alias,bioregistry
 merged.monarch,TOPFIND,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.monarch,topo,http://data.ign.fr/def/topo#,canonical,prefixcc
+merged.monarch,tops,http://www.topbraid.org/tops#,canonical,prefixcc
 merged.monarch,tosh,http://topbraid.org/tosh#,canonical,prefixcc
 merged.monarch,TOXOPLASMA,http://identifiers.org/toxoplasma/,canonical,bioregistry
 merged.monarch,TOXOPLASMA,http://bioregistry.io/toxoplasma:,prefix_alias,bioregistry
@@ -15331,6 +15359,7 @@ merged.monarch,TREEFAM,https://identifiers.org/treefam:,prefix_alias,bioregistry
 merged.monarch,TREEFAM,https://n2t.net/treefam:,prefix_alias,bioregistry
 merged.monarch,TREEFAM,https://www.treefam.org/cgi-bin/TFinfo.pl?ac=,prefix_alias,bioregistry
 merged.monarch,TREEFAM,https://www.treefam.org/family/,prefix_alias,bioregistry
+merged.monarch,TreeGrafter,http://identifiers.org/panther.family/,namespace_alias,go
 merged.monarch,trek,https://w3id.org/trek/,canonical,prefixcc
 merged.monarch,TRICDB,http://identifiers.org/tricdb/,canonical,bioregistry
 merged.monarch,TRICDB,http://biomeddb.org/Disease/Details?DISEASEID=,prefix_alias,bioregistry
@@ -16081,6 +16110,7 @@ merged.monarch,va,http://code-research.eu/ontology/visual-analytics#,canonical,p
 merged.monarch,vacseen1,http://www.semanticweb.org/parthasb/ontologies/2014/6/vacseen1/,canonical,prefixcc
 merged.monarch,vaem,http://www.linkedmodel.org/schema/vaem#,canonical,prefixcc
 merged.monarch,vag,http://www.essepuntato.it/2013/10/vagueness/,canonical,prefixcc
+merged.monarch,vair,https://w3id.org/vair#,canonical,prefixcc
 merged.monarch,VALIDATORDB,http://identifiers.org/pdb/,namespace_alias,bioregistry
 merged.monarch,value,http://gfgfd.vs/,canonical,prefixcc
 merged.monarch,valueflows,https://w3id.org/valueflows/,canonical,prefixcc

--- a/src/prefixmaps/data/merged.oak.csv
+++ b/src/prefixmaps/data/merged.oak.csv
@@ -185,6 +185,7 @@ merged.oak,AfPO,http://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged.oak,AfPO,https://bioregistry.io/AfPO:,prefix_alias,bioregistry
 merged.oak,AfPO,https://purl.obolibrary.org/obo/AfPO_,prefix_alias,bioregistry
 merged.oak,afr,http://purl.allotrope.org/ontologies/result#,canonical,prefixcc
+merged.oak,after,http://rds.posccaesar.org/ontology/plm/ds/,canonical,prefixcc
 merged.oak,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy/,canonical,bioregistry
 merged.oak,AFTOL.TAXONOMY,http://bioregistry.io/aftol.taxonomy:,prefix_alias,bioregistry
 merged.oak,AFTOL.TAXONOMY,http://identifiers.org/aftol.taxonomy:,prefix_alias,bioregistry
@@ -251,7 +252,9 @@ merged.oak,AIO,https://w3id.org/aio/,canonical,bioregistry
 merged.oak,AIO,http://bioregistry.io/aio:,prefix_alias,bioregistry
 merged.oak,AIO,http://w3id.org/aio/,prefix_alias,bioregistry
 merged.oak,AIO,https://bioregistry.io/aio:,prefix_alias,bioregistry
+merged.oak,aio,https://paul.ti.rw.fau.de/~jo00defe/SemWoT/aio#,prefix_alias,prefixcc
 merged.oak,air,http://dig.csail.mit.edu/TAMI/2007/amord/air#,canonical,prefixcc
+merged.oak,airo,https://w3id.org/airo#,canonical,prefixcc
 merged.oak,airport,http://www.daml.org/2001/10/html/airport-ont#,canonical,prefixcc
 merged.oak,airs,https://raw.githubusercontent.com/airs-linked-data/lov/latest/src/airs_vocabulary.ttl#,canonical,prefixcc
 merged.oak,AISM,http://purl.obolibrary.org/obo/AISM_,canonical,obo
@@ -319,6 +322,7 @@ merged.oak,AMPHX,https://www.ebi.ac.uk/ols/ontologies/amphx/terms?iri=http://pur
 merged.oak,ams,http://data.amadeus.com/,canonical,prefixcc
 merged.oak,amsl,http://vocab.ub.uni-leipzig.de/amsl/,canonical,prefixcc
 merged.oak,amt,http://academic-meta-tool.xyz/vocab#,canonical,prefixcc
+merged.oak,amv,https://w3id.org/amv/,canonical,prefixcc
 merged.oak,anca,http://users.utcluj.ro/~raluca/rdf_ontologies_ralu/ralu_modified_ontology_pizzas2_0#,canonical,prefixcc
 merged.oak,aneo,http://akonadi-project.org/ontologies/aneo#,canonical,prefixcc
 merged.oak,ann,http://www.w3.org/2000/10/annotation-ns#,canonical,prefixcc
@@ -422,6 +426,7 @@ merged.oak,api,http://purl.org/linked-data/api/vocab#,canonical,prefixcc
 merged.oak,APID.INTERACTIONS,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.oak,APIDB_PLASMODB,http://identifiers.org/plasmodb/,namespace_alias,bioregistry
 merged.oak,apivc,http://purl.org/linked-data/api/vocab#,namespace_alias,prefixcc
+merged.oak,apmwg,http://apmwg.ovh/,canonical,prefixcc
 merged.oak,APO,http://purl.obolibrary.org/obo/APO_,canonical,obo
 merged.oak,APO,http://bioregistry.io/APO:,prefix_alias,bioregistry
 merged.oak,APO,http://www.ebi.ac.uk/ols/ontologies/apo/terms?iri=http://purl.obolibrary.org/obo/APO_,prefix_alias,bioregistry
@@ -1135,6 +1140,7 @@ merged.oak,BIOMINDER,https://datalab.rwth-aachen.de/MINDER/resource/,prefix_alia
 merged.oak,BIOMINDER,https://identifiers.org/biominder/,prefix_alias,bioregistry
 merged.oak,BIOMINDER,https://identifiers.org/biominder:,prefix_alias,bioregistry
 merged.oak,BIOMINDER,https://n2t.net/biominder:,prefix_alias,bioregistry
+merged.oak,biomodels,http://purl.obolibrary.org/obo/KISAO_,namespace_alias,prefixcc
 merged.oak,BIOMODELS.DB,http://identifiers.org/biomodels.db/,canonical,bioregistry
 merged.oak,BIOMODELS.DB,http://bio2rdf.org/biomodels:,prefix_alias,bioregistry
 merged.oak,BIOMODELS.DB,http://biomodels.caltech.edu/,prefix_alias,bioregistry
@@ -1422,6 +1428,7 @@ merged.oak,bn,http://babelnet.org/rdf/,canonical,prefixcc
 merged.oak,bne,http://datos.bne.es/resource/,canonical,prefixcc
 merged.oak,bner,http://datos.bne.es/resource/,namespace_alias,prefixcc
 merged.oak,bnf,http://www.w3.org/2000/10/swap/grammar/bnf#,canonical,prefixcc
+merged.oak,bng,https://w3id.org/dob/voc/epsg-27700#,canonical,prefixcc
 merged.oak,bob,http://good.dad/meaning/bob#,canonical,prefixcc
 merged.oak,BOLD.TAXONOMY,http://identifiers.org/bold.taxonomy/,canonical,bioregistry
 merged.oak,BOLD.TAXONOMY,http://bio2rdf.org/bold:,prefix_alias,bioregistry
@@ -2406,6 +2413,7 @@ merged.oak,CMPO,http://www.ebi.ac.uk/cmpo/CMPO_,canonical,bioregistry
 merged.oak,CMPO,http://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged.oak,CMPO,https://bioregistry.io/cmpo:,prefix_alias,bioregistry
 merged.oak,CMPO,https://www.ebi.ac.uk/cmpo/CMPO_,prefix_alias,bioregistry
+merged.oak,cmso,http://purls.helmholtz-metadaten.de/cmso/,canonical,prefixcc
 merged.oak,cnt,http://www.w3.org/2011/content#,canonical,prefixcc
 merged.oak,co,http://purl.org/ontology/co/core#,canonical,prefixcc
 merged.oak,CO_320,https://cropontology.org/rdf/CO_320:,canonical,bioregistry
@@ -2812,6 +2820,7 @@ merged.oak,CPT,http://www.aapc.com/codes/cpt-codes/,prefix_alias,bioregistry
 merged.oak,CPT,https://bioregistry.io/ama-cpt:,prefix_alias,bioregistry
 merged.oak,CPT,https://bioregistry.io/cpt:,prefix_alias,bioregistry
 merged.oak,cpv,http://purl.org/weso/cpv/,canonical,prefixcc
+merged.oak,cr,http://mlcommons.org/croissant/,canonical,prefixcc
 merged.oak,CRAN,https://cran.r-project.org/web/packages/,canonical,bioregistry
 merged.oak,CRAN,http://CRAN.R-project.org/package=,prefix_alias,bioregistry
 merged.oak,CRAN,http://bioregistry.io/cran:,prefix_alias,bioregistry
@@ -2842,9 +2851,10 @@ merged.oak,CRISPRDB,https://n2t.net/crisprdb:,prefix_alias,bioregistry
 merged.oak,crm,http://www.cidoc-crm.org/cidoc-crm/,canonical,prefixcc
 merged.oak,crmdig,http://www.ics.forth.gr/isl/CRMdig/,canonical,prefixcc
 merged.oak,crmeh,http://purl.org/crmeh#,canonical,prefixcc
+merged.oak,crmgeo,http://www.ics.forth.gr/isl/CRMgeo/,canonical,prefixcc
 merged.oak,crminf,http://www.cidoc-crm.org/cidoc-crm/CRMinf/,canonical,prefixcc
 merged.oak,crml,http://semweb.mmlab.be/ns/rml/condition#,canonical,prefixcc
-merged.oak,crmsci,http://cidoc-crm.org/crmsci/,canonical,prefixcc
+merged.oak,crmsci,http://www.cidoc-crm.org/extensions/crmsci/,canonical,prefixcc
 merged.oak,CRO,http://purl.obolibrary.org/obo/CRO_,canonical,obo
 merged.oak,CRO,http://bioregistry.io/CRO:,prefix_alias,bioregistry
 merged.oak,CRO,http://www.ebi.ac.uk/ols/ontologies/cro/terms?iri=http://purl.obolibrary.org/obo/CRO_,prefix_alias,bioregistry
@@ -3542,6 +3552,7 @@ merged.oak,DID,https://identifiers.org/DID:,prefix_alias,bioregistry
 merged.oak,DID,https://identifiers.org/did/did:,prefix_alias,bioregistry
 merged.oak,DID,https://n2t.net/did:,prefix_alias,bioregistry
 merged.oak,DID,https://uniresolver.io/#did:,prefix_alias,bioregistry
+merged.oak,did,https://w3id.org/dob/id/,prefix_alias,prefixcc
 merged.oak,DIDEO,http://purl.obolibrary.org/obo/DIDEO_,canonical,obo
 merged.oak,DIDEO,http://bioregistry.io/DIDEO:,prefix_alias,bioregistry
 merged.oak,DIDEO,http://www.ebi.ac.uk/ols/ontologies/dideo/terms?iri=http://purl.obolibrary.org/obo/DIDEO_,prefix_alias,bioregistry
@@ -3648,6 +3659,7 @@ merged.oak,doap,http://bioregistry.io/doap:,prefix_alias,bioregistry
 merged.oak,doap,https://bioregistry.io/doap:,prefix_alias,bioregistry
 merged.oak,doap,https://usefulinc.com/ns/doap#,prefix_alias,bioregistry
 merged.oak,doas,http://deductions.github.io/doas.owl.ttl#,canonical,prefixcc
+merged.oak,dob,https://w3id.org/dob/voc#,canonical,prefixcc
 merged.oak,doc,http://www.w3.org/2000/10/swap/pim/doc#,canonical,prefixcc
 merged.oak,docam,https://www.docam.ca/glossaurus/,canonical,prefixcc
 merged.oak,docbook,http://docbook.org/ns/docbook/,canonical,prefixcc
@@ -3732,6 +3744,7 @@ merged.oak,DOOR,https://identifiers.org/door/,prefix_alias,bioregistry
 merged.oak,DOOR,https://identifiers.org/door:,prefix_alias,bioregistry
 merged.oak,DOOR,https://n2t.net/door:,prefix_alias,bioregistry
 merged.oak,door,http://kannel.open.ac.uk/ontology#,prefix_alias,prefixcc
+merged.oak,dop,https://w3id.org/dob/voc/prop#,canonical,prefixcc
 merged.oak,DOQCS.MODEL,http://identifiers.org/doqcs.model/,canonical,bioregistry
 merged.oak,DOQCS.MODEL,http://bio2rdf.org/doqcs.model:,prefix_alias,bioregistry
 merged.oak,DOQCS.MODEL,http://bioregistry.io/doqcs.model:,prefix_alias,bioregistry
@@ -4156,6 +4169,7 @@ merged.oak,ecoll,http://purl.org/ceu/eco/1.0#,canonical,prefixcc
 merged.oak,ecore,http://www.eclipse.org/emf/2002/Ecore#,canonical,prefixcc
 merged.oak,ecos,http://purl.org/ecos#,canonical,prefixcc
 merged.oak,ecowlim,http://ecowlim.tfri.gov.tw/lode/resource/,canonical,prefixcc
+merged.oak,ecp,http://www.ebu.ch/metadata/ontologies/ebucoreplus#,canonical,prefixcc
 merged.oak,ecpo,http://purl.org/ontology/ecpo#,canonical,prefixcc
 merged.oak,ecrm,http://erlangen-crm.org/current/,canonical,prefixcc
 merged.oak,ecs,http://rdf.ecs.soton.ac.uk/ontology/ecs#,canonical,prefixcc
@@ -4250,6 +4264,7 @@ merged.oak,edgarcik,http://edgarwrap.ontologycentral.com/cik/,canonical,prefixcc
 merged.oak,edm,http://www.europeana.eu/schemas/edm/,canonical,prefixcc
 merged.oak,edo,http://semanticweb.org/edo#,canonical,prefixcc
 merged.oak,edr,https://w3id.org/laas-iot/edr#,canonical,prefixcc
+merged.oak,edtf,http://id.loc.gov/datatypes/EDTFScheme/,canonical,prefixcc
 merged.oak,edu,https://schema.edu.ee/,canonical,prefixcc
 merged.oak,edupro,http://ns.inria.fr/semed/eduprogression#,canonical,prefixcc
 merged.oak,eem,http://purl.org/eem#,canonical,prefixcc
@@ -5598,7 +5613,7 @@ merged.oak,GIARDIADB,https://giardiadb.org/giardiadb/showRecord.do?name=GeneReco
 merged.oak,GIARDIADB,https://identifiers.org/giardiadb/,prefix_alias,bioregistry
 merged.oak,GIARDIADB,https://identifiers.org/giardiadb:,prefix_alias,bioregistry
 merged.oak,GIARDIADB,https://n2t.net/giardiadb:,prefix_alias,bioregistry
-merged.oak,gist,https://ontologies.semanticarts.com/o/gistCore#,canonical,prefixcc
+merged.oak,gist,http://ontologies.semanticarts.com/gist#,canonical,prefixcc
 merged.oak,GITHUB,http://identifiers.org/github/,canonical,bioregistry
 merged.oak,GITHUB,http://bioregistry.io/github:,prefix_alias,bioregistry
 merged.oak,GITHUB,http://github.com/,prefix_alias,bioregistry
@@ -5881,6 +5896,7 @@ merged.oak,GO.RESOURCE,https://bioregistry.io/metaregistry/go/,canonical,bioregi
 merged.oak,GO.RESOURCE,http://bioregistry.io/go.resource:,prefix_alias,bioregistry
 merged.oak,GO.RESOURCE,http://bioregistry.io/metaregistry/go/,prefix_alias,bioregistry
 merged.oak,GO.RESOURCE,https://bioregistry.io/go.resource:,prefix_alias,bioregistry
+merged.oak,GO_REF,http://purl.obolibrary.org/obo/go/references/,canonical,go
 merged.oak,GOA,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.oak,goaf,http://goaf.fr/goaf#,canonical,prefixcc
 merged.oak,goavoc,http://bio2rdf.org/goa_vocabulary:,canonical,prefixcc
@@ -6138,7 +6154,7 @@ merged.oak,GRSDB,https://bioregistry.io/grsdb:,prefix_alias,bioregistry
 merged.oak,GRSDB,https://identifiers.org/grsdb/,prefix_alias,bioregistry
 merged.oak,GRSDB,https://identifiers.org/grsdb:,prefix_alias,bioregistry
 merged.oak,GRSDB,https://n2t.net/grsdb:,prefix_alias,bioregistry
-merged.oak,gs1,http://gs1.org/voc/,canonical,prefixcc
+merged.oak,gs1,https://ref.gs1.org/voc/,canonical,prefixcc
 merged.oak,gso,http://www.w3.org/2006/gen/ont#,canonical,prefixcc
 merged.oak,gsp,http://www.opengis.net/ont/geosparql#,namespace_alias,prefixcc
 merged.oak,GSSO,http://purl.obolibrary.org/obo/GSSO_,canonical,obo
@@ -7885,6 +7901,7 @@ merged.oak,kpd,http://purl.org/kpd/,canonical,prefixcc
 merged.oak,ksam,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged.oak,ksamsok,http://kulturarvsdata.se/ksamsok#,namespace_alias,prefixcc
 merged.oak,kupkb,http://www.e-lico.eu/data/kupkb/,canonical,prefixcc
+merged.oak,kvasir,https://kvasir.discover.ilabt.imec.be/vocab#,canonical,prefixcc
 merged.oak,kw,http://kwantu.net/kw/,canonical,prefixcc
 merged.oak,kwijibo,http://kwijibo.talis.com/,canonical,prefixcc
 merged.oak,l2sp,http://www.linked2safety-project.eu/properties/,canonical,prefixcc
@@ -8130,6 +8147,7 @@ merged.oak,linkml,http://w3id.org/linkml/,prefix_alias,bioregistry
 merged.oak,linkml,https://bioregistry.io/linkml:,prefix_alias,bioregistry
 merged.oak,linkrel,https://www.w3.org/ns/iana/link-relations/relation#,namespace_alias,prefixcc
 merged.oak,lio,http://purl.org/net/lio#,canonical,prefixcc
+merged.oak,liph,https://gallosiciliani.unict.it/ns/lpont#,canonical,prefixcc
 merged.oak,LIPID MAPS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged.oak,LIPID_MAPS_CLASS,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
 merged.oak,LIPID_MAPS_INSTANCE,http://identifiers.org/lipidmaps/,namespace_alias,bioregistry
@@ -8354,6 +8372,7 @@ merged.oak,MAGGOT,https://identifiers.org/maggot:,prefix_alias,bioregistry
 merged.oak,MAGGOT,https://pmb-bordeaux.fr/maggot/metadata/,prefix_alias,bioregistry
 merged.oak,magmardl,http://www.semanticweb.org/magma-core/rdl#,canonical,prefixcc
 merged.oak,magmauser,http://www.semanticweb.org/magma-core/user#,canonical,prefixcc
+merged.oak,maid,https://mutual-aid.app/ns/core#,canonical,prefixcc
 merged.oak,MAIZEGDB,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged.oak,MAIZEGDB.LOCUS,http://bio2rdf.org/maizegdb:,prefix_alias,bioregistry
 merged.oak,MAIZEGDB.LOCUS,http://bioregistry.io/MaizeGDB:,prefix_alias,bioregistry
@@ -8374,6 +8393,7 @@ merged.oak,MAIZEGDB.LOCUS,https://www.maizegdb.org/data_center/gene_product?id=,
 merged.oak,MAIZEGDB.LOCUS,https://www.maizegdb.org/gene_center/gene/,prefix_alias,bioregistry
 merged.oak,MAIZEGDB.LOCUS,http://identifiers.org/maizegdb.locus/,namespace_alias,bioregistry
 merged.oak,MaizeGDB_Locus,http://identifiers.org/maizegdb.locus/,canonical,go
+merged.oak,makeup,http://example.org/makeup#,canonical,prefixcc
 merged.oak,malaka,http://george.gr/,canonical,prefixcc
 merged.oak,malignneo,http://www.agfa.com/w3c/2009/malignantNeoplasm#,canonical,prefixcc
 merged.oak,mammal,http://lod.taxonconcept.org/ontology/p01/Mammalia/index.owl#,canonical,prefixcc
@@ -8573,6 +8593,7 @@ merged.oak,MEDLINEPLUS,https://identifiers.org/medlineplus:,prefix_alias,bioregi
 merged.oak,MEDLINEPLUS,https://n2t.net/medlineplus:,prefix_alias,bioregistry
 merged.oak,MEDRA,http://identifiers.org/meddra/,namespace_alias,bioregistry
 merged.oak,medred,http://w3id.org/medred/medred#,canonical,prefixcc
+merged.oak,mee,http://www.w3.org/ns/pim/meeting#,canonical,prefixcc
 merged.oak,meeting,http://www.w3.org/2002/07/meeting#,canonical,prefixcc
 merged.oak,meetup,http://www.lotico.com/meetup/,canonical,prefixcc
 merged.oak,mei,http://www.music-encoding.org/ns/mei/,canonical,prefixcc
@@ -9670,6 +9691,7 @@ merged.oak,MZSPEC,https://identifiers.org/mzspec/mzspec:,prefix_alias,bioregistr
 merged.oak,MZSPEC,https://n2t.net/mzspec:,prefix_alias,bioregistry
 merged.oak,MZSPEC,https://proteomecentral.proteomexchange.org/usi/?usi=mzspec:,prefix_alias,bioregistry
 merged.oak,MZSPEC,https://www.ebi.ac.uk/pride/archive/usi?usi=mzspec:,prefix_alias,bioregistry
+merged.oak,nace2,http://data.europa.eu/ux2/nace2/,canonical,prefixcc
 merged.oak,nalt,https://lod.nal.usda.gov/nalt/,canonical,prefixcc
 merged.oak,name,http://example.org/name#,canonical,prefixcc
 merged.oak,namespaces,https://vg.no/,canonical,prefixcc
@@ -11092,6 +11114,7 @@ merged.oak,OPENWEMI,https://dcmi.github.io/openwemi/ns#,canonical,bioregistry
 merged.oak,OPENWEMI,http://bioregistry.io/openwemi:,prefix_alias,bioregistry
 merged.oak,OPENWEMI,http://dcmi.github.io/openwemi/ns#,prefix_alias,bioregistry
 merged.oak,OPENWEMI,https://bioregistry.io/openwemi:,prefix_alias,bioregistry
+merged.oak,openwemi,https://ns.dublincore.org/openwemi/,prefix_alias,prefixcc
 merged.oak,oper,http://sweet.jpl.nasa.gov/2.0/mathOperation.owl#,canonical,prefixcc
 merged.oak,OPL,http://purl.obolibrary.org/obo/OPL_,canonical,obo
 merged.oak,OPL,http://bioregistry.io/OPL:,prefix_alias,bioregistry
@@ -11579,8 +11602,8 @@ merged.oak,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein/,prefix_alias,bio
 merged.oak,PAXDB.PROTEIN,https://identifiers.org/paxdb.protein:,prefix_alias,bioregistry
 merged.oak,PAXDB.PROTEIN,https://n2t.net/paxdb.protein:,prefix_alias,bioregistry
 merged.oak,PAXDB.PROTEIN,https://pax-db.org/#!protein/,prefix_alias,bioregistry
-merged.oak,pay,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
-merged.oak,payment,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged.oak,pay,http://reference.data.gov.uk/def/payment#,canonical,prefixcc
+merged.oak,payment,http://reference.data.gov.uk/def/payment#,namespace_alias,prefixcc
 merged.oak,PAZAR,http://identifiers.org/pazar/,canonical,bioregistry
 merged.oak,PAZAR,http://bio2rdf.org/pazar:,prefix_alias,bioregistry
 merged.oak,PAZAR,http://bioregistry.io/pazar:,prefix_alias,bioregistry
@@ -12245,7 +12268,7 @@ merged.oak,PMDB,https://identifiers.org/pmdb:,prefix_alias,bioregistry
 merged.oak,PMDB,https://mi.caspur.it/PMDB/user/search.php?idsearch=,prefix_alias,bioregistry
 merged.oak,PMDB,https://n2t.net/pmdb:,prefix_alias,bioregistry
 merged.oak,pmhb,http://pmhb.org/,canonical,prefixcc
-merged.oak,PMID,http://identifiers.org/pubmed/,namespace_alias,bioregistry
+merged.oak,PMID,http://identifiers.org/pubmed/,canonical,go
 merged.oak,pml,http://provenanceweb.org/ns/pml#,canonical,prefixcc
 merged.oak,pmlj,http://inference-web.org/2.0/pml-justification.owl#,canonical,prefixcc
 merged.oak,pmlp,http://inference-web.org/2.0/pml-provenance.owl#,canonical,prefixcc
@@ -12661,6 +12684,7 @@ merged.oak,PSIPAR,https://identifiers.org/psipar:,prefix_alias,bioregistry
 merged.oak,PSIPAR,https://n2t.net/psipar:,prefix_alias,bioregistry
 merged.oak,PSIPAR,https://www.ebi.ac.uk/ontology-lookup/?termId=PAR:,prefix_alias,bioregistry
 merged.oak,psm,https://paul.ti.rw.fau.de/~jo00defe/ont/psm#,canonical,prefixcc
+merged.oak,psn,https://purl.org/psn/vocab#,canonical,prefixcc
 merged.oak,PSO,http://purl.obolibrary.org/obo/PSO_,canonical,obo
 merged.oak,PSO,http://bioregistry.io/PSO:,prefix_alias,bioregistry
 merged.oak,PSO,http://www.ebi.ac.uk/ols/ontologies/pso/terms?iri=http://purl.obolibrary.org/obo/PSO_,prefix_alias,bioregistry
@@ -12768,7 +12792,6 @@ merged.oak,PUBLONS.RESEARCHER,https://publons.com/researcher/,canonical,bioregis
 merged.oak,PUBLONS.RESEARCHER,http://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
 merged.oak,PUBLONS.RESEARCHER,http://publons.com/researcher/,prefix_alias,bioregistry
 merged.oak,PUBLONS.RESEARCHER,https://bioregistry.io/publons.researcher:,prefix_alias,bioregistry
-merged.oak,PUBMED,http://identifiers.org/pubmed/,canonical,bioregistry
 merged.oak,PUBMED,http://bio2rdf.org/pubmed:,prefix_alias,bioregistry
 merged.oak,PUBMED,http://bioregistry.io/MEDLINE:,prefix_alias,bioregistry
 merged.oak,PUBMED,http://bioregistry.io/PMID:,prefix_alias,bioregistry
@@ -12801,6 +12824,7 @@ merged.oak,PUBMED,https://scholia.toolforge.org/pubmed/,prefix_alias,bioregistry
 merged.oak,PUBMED,https://www.hubmed.org/display.cgi?uids=,prefix_alias,bioregistry
 merged.oak,PUBMED,https://www.ncbi.nlm.nih.gov/pubmed/,prefix_alias,bioregistry
 merged.oak,pubmed,http://bio2rdf.org/pubmed_vocabulary:,prefix_alias,prefixcc
+merged.oak,PUBMED,http://identifiers.org/pubmed/,namespace_alias,bioregistry
 merged.oak,puc,http://purl.org/NET/puc#,canonical,prefixcc
 merged.oak,puelia,http://kwijibo.talis.com/vocabs/puelia#,canonical,prefixcc
 merged.oak,puml,http://plantuml.com/ontology#,canonical,prefixcc
@@ -13121,6 +13145,7 @@ merged.oak,RDFA,https://www.w3.org/ns/rdfa#,prefix_alias,bioregistry
 merged.oak,rdfdata,http://rdf.data-vocabulary.org/rdf.xml#,canonical,prefixcc
 merged.oak,rdfdf,http://www.openlinksw.com/virtrdf-data-formats#,canonical,prefixcc
 merged.oak,rdfg,http://www.w3.org/2004/03/trix/rdfg-1/,canonical,prefixcc
+merged.oak,rdfl,https://w3id.org/rdf-lens/ontology#,canonical,prefixcc
 merged.oak,rdfp,https://w3id.org/rdfp/,canonical,prefixcc
 merged.oak,rdfs,http://www.w3.org/2000/01/rdf-schema#,canonical,linkml
 merged.oak,rdfs,http://bioregistry.io/rdfs:,prefix_alias,bioregistry
@@ -13754,6 +13779,7 @@ merged.oak,schema,http://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged.oak,schema,https://bioregistry.io/schema:,prefix_alias,bioregistry
 merged.oak,schema,https://bioregistry.io/schemaorg:,prefix_alias,bioregistry
 merged.oak,schemaorg,https://schema.org/,namespace_alias,bioregistry
+merged.oak,schemas,https://schema.org/,namespace_alias,prefixcc
 merged.oak,scho,http://www.scholarlydata.org/ontology/conference-ontology.owl#,canonical,prefixcc
 merged.oak,schoi,https://w3id.org/scholarlydata/ontology/indicators-ontology.owl#,canonical,prefixcc
 merged.oak,SCHOLIA.RESOURCE,https://bioregistry.io/metaregistry/scholia/,canonical,bioregistry
@@ -15147,6 +15173,7 @@ merged.oak,test2,http://this.invalid/test2#,canonical,prefixcc
 merged.oak,text,http://jena.apache.org/text#,canonical,prefixcc
 merged.oak,textgrid,https://textgridrep.org/,canonical,prefixcc
 merged.oak,tg,https://triplydb.com/Triply/tg/def/,canonical,prefixcc
+merged.oak,tgc,http://www.hds.utc.fr/tg#,canonical,prefixcc
 merged.oak,TGD,http://identifiers.org/tgd/,canonical,go
 merged.oak,TGD,http://bio2rdf.org/tgd:,prefix_alias,bioregistry
 merged.oak,TGD,http://bioregistry.io/tgd:,prefix_alias,bioregistry
@@ -15267,6 +15294,7 @@ merged.oak,TOPDB,https://n2t.net/topdb:,prefix_alias,bioregistry
 merged.oak,TOPDB,https://topdb.enzim.hu/?m=show&id=,prefix_alias,bioregistry
 merged.oak,TOPFIND,http://identifiers.org/uniprot/,namespace_alias,bioregistry
 merged.oak,topo,http://data.ign.fr/def/topo#,canonical,prefixcc
+merged.oak,tops,http://www.topbraid.org/tops#,canonical,prefixcc
 merged.oak,tosh,http://topbraid.org/tosh#,canonical,prefixcc
 merged.oak,TOXOPLASMA,http://identifiers.org/toxoplasma/,canonical,bioregistry
 merged.oak,TOXOPLASMA,http://bioregistry.io/toxoplasma:,prefix_alias,bioregistry
@@ -15331,6 +15359,7 @@ merged.oak,TREEFAM,https://identifiers.org/treefam:,prefix_alias,bioregistry
 merged.oak,TREEFAM,https://n2t.net/treefam:,prefix_alias,bioregistry
 merged.oak,TREEFAM,https://www.treefam.org/cgi-bin/TFinfo.pl?ac=,prefix_alias,bioregistry
 merged.oak,TREEFAM,https://www.treefam.org/family/,prefix_alias,bioregistry
+merged.oak,TreeGrafter,http://identifiers.org/panther.family/,namespace_alias,go
 merged.oak,trek,https://w3id.org/trek/,canonical,prefixcc
 merged.oak,TRICDB,http://identifiers.org/tricdb/,canonical,bioregistry
 merged.oak,TRICDB,http://biomeddb.org/Disease/Details?DISEASEID=,prefix_alias,bioregistry
@@ -16081,6 +16110,7 @@ merged.oak,va,http://code-research.eu/ontology/visual-analytics#,canonical,prefi
 merged.oak,vacseen1,http://www.semanticweb.org/parthasb/ontologies/2014/6/vacseen1/,canonical,prefixcc
 merged.oak,vaem,http://www.linkedmodel.org/schema/vaem#,canonical,prefixcc
 merged.oak,vag,http://www.essepuntato.it/2013/10/vagueness/,canonical,prefixcc
+merged.oak,vair,https://w3id.org/vair#,canonical,prefixcc
 merged.oak,VALIDATORDB,http://identifiers.org/pdb/,namespace_alias,bioregistry
 merged.oak,value,http://gfgfd.vs/,canonical,prefixcc
 merged.oak,valueflows,https://w3id.org/valueflows/,canonical,prefixcc

--- a/src/prefixmaps/data/prefixcc.csv
+++ b/src/prefixmaps/data/prefixcc.csv
@@ -29,6 +29,7 @@ prefixcc,adr,http://kg.artsdata.ca/resource/,canonical
 prefixcc,adw,https://animaldiversity.org/accounts/,canonical
 prefixcc,aec3po,https://w3id.org/lbd/aec3po/,canonical
 prefixcc,aeo,http://purl.obolibrary.org/obo/AEO_,canonical
+prefixcc,aero,http://purl.obolibrary.org/obo/AERO_,canonical
 prefixcc,aerols,http://xmlns.com/aerols/0.1/,canonical
 prefixcc,aers,http://aers.data2semantics.org/resource/,canonical
 prefixcc,aersv,http://aers.data2semantics.org/vocab/,canonical
@@ -40,6 +41,7 @@ prefixcc,afm,http://purl.allotrope.org/ontologies/material/,canonical
 prefixcc,afn,http://jena.apache.org/ARQ/function#,canonical
 prefixcc,afpo,http://purl.obolibrary.org/obo/AfPO_,canonical
 prefixcc,afr,http://purl.allotrope.org/ontologies/result#,canonical
+prefixcc,after,http://rds.posccaesar.org/ontology/plm/ds/,canonical
 prefixcc,agent,http://eulersharp.sourceforge.net/2003/03swap/agent#,canonical
 prefixcc,agents,http://eulersharp.sourceforge.net/2003/03swap/agent#,namespace_alias
 prefixcc,agetec,http://www.agetec.org/,canonical
@@ -57,7 +59,9 @@ prefixcc,aigp,http://swat.cse.lehigh.edu/resources/onto/aigp.owl#,canonical
 prefixcc,aiiso,http://purl.org/vocab/aiiso/schema#,canonical
 prefixcc,aimaix,https://w3id.org/aimaix#,canonical
 prefixcc,aims,http://aims.fao.org/aos/common/,canonical
+prefixcc,aio,https://paul.ti.rw.fau.de/~jo00defe/SemWoT/aio#,canonical
 prefixcc,air,http://dig.csail.mit.edu/TAMI/2007/amord/air#,canonical
+prefixcc,airo,https://w3id.org/airo#,canonical
 prefixcc,airport,http://www.daml.org/2001/10/html/airport-ont#,canonical
 prefixcc,airs,https://raw.githubusercontent.com/airs-linked-data/lov/latest/src/airs_vocabulary.ttl#,canonical
 prefixcc,aism,http://purl.obolibrary.org/obo/AISM_,canonical
@@ -81,6 +85,7 @@ prefixcc,amphx,http://purl.obolibrary.org/obo/AMPHX_,canonical
 prefixcc,ams,http://data.amadeus.com/,canonical
 prefixcc,amsl,http://vocab.ub.uni-leipzig.de/amsl/,canonical
 prefixcc,amt,http://academic-meta-tool.xyz/vocab#,canonical
+prefixcc,amv,https://w3id.org/amv/,canonical
 prefixcc,anca,http://users.utcluj.ro/~raluca/rdf_ontologies_ralu/ralu_modified_ontology_pizzas2_0#,canonical
 prefixcc,aneo,http://akonadi-project.org/ontologies/aneo#,canonical
 prefixcc,ann,http://www.w3.org/2000/10/annotation-ns#,canonical
@@ -92,6 +97,7 @@ prefixcc,apb,http://www.analysispartners.org/businessmodel/,canonical
 prefixcc,apf,http://jena.apache.org/ARQ/property#,canonical
 prefixcc,api,http://purl.org/linked-data/api/vocab#,canonical
 prefixcc,apivc,http://purl.org/linked-data/api/vocab#,namespace_alias
+prefixcc,apmwg,http://apmwg.ovh/,canonical
 prefixcc,apo,http://purl.obolibrary.org/obo/APO_,canonical
 prefixcc,apods,http://activitypods.org/ns/core#,canonical
 prefixcc,apollosv,http://purl.obolibrary.org/obo/APOLLO_SV_,canonical
@@ -211,6 +217,7 @@ prefixcc,bioentity,http://bioentity.io/vocab/,canonical
 prefixcc,biogrid,http://thebiogrid.org/,canonical
 prefixcc,biol,http://purl.org/NET/biol/ns#,canonical
 prefixcc,biolink,https://w3id.org/biolink/vocab/,namespace_alias
+prefixcc,biomodels,http://purl.obolibrary.org/obo/KISAO_,canonical
 prefixcc,biopax,http://www.biopax.org/release/biopax-level3.owl#,canonical
 prefixcc,biordf,http://purl.org/net/biordfmicroarray/ns#,canonical
 prefixcc,bioschemas,https://bioschemas.org/,canonical
@@ -235,6 +242,7 @@ prefixcc,bn,http://babelnet.org/rdf/,canonical
 prefixcc,bne,http://datos.bne.es/resource/,canonical
 prefixcc,bner,http://datos.bne.es/resource/,namespace_alias
 prefixcc,bnf,http://www.w3.org/2000/10/swap/grammar/bnf#,canonical
+prefixcc,bng,https://w3id.org/dob/voc/epsg-27700#,canonical
 prefixcc,bob,http://good.dad/meaning/bob#,canonical
 prefixcc,book,http://purl.org/NET/book/vocab#,canonical
 prefixcc,bookmark,http://www.w3.org/2002/01/bookmark#,canonical
@@ -339,6 +347,7 @@ prefixcc,chems,https://w3id.org/emmo/domain/chemical-substance#,canonical
 prefixcc,chemsci,https://w3id.org/skgo/chemsci#,canonical
 prefixcc,chess,http://purl.org/NET/rdfchess/ontology/,canonical
 prefixcc,chiro,http://purl.obolibrary.org/obo/CHIRO_,canonical
+prefixcc,chmo,http://purl.obolibrary.org/obo/CHMO_,canonical
 prefixcc,chord,http://purl.org/ontology/chord/,canonical
 prefixcc,chpaf,https://ch.paf.link/,canonical
 prefixcc,ci,https://privatealpha.com/ontology/content-inventory/1#,canonical
@@ -370,8 +379,10 @@ prefixcc,clyh,http://purl.obolibrary.org/obo/ZP_,namespace_alias
 prefixcc,cmd,https://w3id.org/cmd#,canonical
 prefixcc,cmdi,http://www.clarin.eu/cmd/,canonical
 prefixcc,cmdm,http://infra.clarin.eu/cmd/,canonical
+prefixcc,cmf,http://purl.obolibrary.org/obo/CMF_,canonical
 prefixcc,cmo,http://purl.org/twc/ontologies/cmo.owl#,canonical
 prefixcc,cmp,http://www.ontologydesignpatterns.org/cp/owl/componency.owl#,canonical
+prefixcc,cmso,http://purls.helmholtz-metadaten.de/cmso/,canonical
 prefixcc,cnt,http://www.w3.org/2011/content#,canonical
 prefixcc,co,http://purl.org/ontology/co/core#,canonical
 prefixcc,cob,http://purl.obolibrary.org/obo/COB_,canonical
@@ -441,6 +452,7 @@ prefixcc,cpov,http://data.europa.eu/m8g/,canonical
 prefixcc,cpsv,http://purl.org/vocab/cpsv#,canonical
 prefixcc,cpsvno,http://data.norge.no/vocabulary/cpsvno#,canonical
 prefixcc,cpv,http://purl.org/weso/cpv/,canonical
+prefixcc,cr,http://mlcommons.org/croissant/,canonical
 prefixcc,crcr,https://credit.niso.org/contributor-roles/,canonical
 prefixcc,cred,https://www.w3.org/2018/credentials#,canonical
 prefixcc,credit,https://credit.niso.org/,canonical
@@ -448,9 +460,10 @@ prefixcc,crime,http://purl.org/vocab/reloc/,canonical
 prefixcc,crm,http://www.cidoc-crm.org/cidoc-crm/,canonical
 prefixcc,crmdig,http://www.ics.forth.gr/isl/CRMdig/,canonical
 prefixcc,crmeh,http://purl.org/crmeh#,canonical
+prefixcc,crmgeo,http://www.ics.forth.gr/isl/CRMgeo/,canonical
 prefixcc,crminf,http://www.cidoc-crm.org/cidoc-crm/CRMinf/,canonical
 prefixcc,crml,http://semweb.mmlab.be/ns/rml/condition#,canonical
-prefixcc,crmsci,http://cidoc-crm.org/crmsci/,canonical
+prefixcc,crmsci,http://www.cidoc-crm.org/extensions/crmsci/,canonical
 prefixcc,cro,http://rhizomik.net/ontologies/copyrightonto.owl#,canonical
 prefixcc,crowd,http://purl.org/crowd/,canonical
 prefixcc,crsw,http://courseware.rkbexplorer.com/ontologies/courseware#,namespace_alias
@@ -615,8 +628,9 @@ prefixcc,diag,http://www.loc.gov/zing/srw/diagnostic/,canonical
 prefixcc,dicera,http://semweb.mmlab.be/ns/dicera#,canonical
 prefixcc,dick,http://pornhub.com/,namespace_alias
 prefixcc,dicom,http://purl.org/healthcarevocab/v1#,canonical
+prefixcc,did,https://w3id.org/dob/id/,canonical
 prefixcc,dideo,http://purl.obolibrary.org/obo/DIDEO_,canonical
-prefixcc,dinto,http://purl.obolibrary.org/obo/ZP_,canonical
+prefixcc,dinto,http://purl.obolibrary.org/obo/ZP_,namespace_alias
 prefixcc,dio,https://w3id.org/dio#,canonical
 prefixcc,dir,http://schemas.talis.com/2005/dir/schema#,canonical
 prefixcc,dis,http://stanbol.apache.org/ontology/disambiguation/disambiguation#,canonical
@@ -643,6 +657,7 @@ prefixcc,doacc,http://purl.org/net/bel-epa/doacc#,canonical
 prefixcc,doam,http://emmo.info/doam#,canonical
 prefixcc,doap,http://usefulinc.com/ns/doap#,canonical
 prefixcc,doas,http://deductions.github.io/doas.owl.ttl#,canonical
+prefixcc,dob,https://w3id.org/dob/voc#,canonical
 prefixcc,doc,http://www.w3.org/2000/10/swap/pim/doc#,canonical
 prefixcc,docam,https://www.docam.ca/glossaurus/,canonical
 prefixcc,docbook,http://docbook.org/ns/docbook/,canonical
@@ -656,6 +671,7 @@ prefixcc,doid,http://purl.obolibrary.org/obo/DOID_,canonical
 prefixcc,dom,https://html.spec.whatwg.org/#,canonical
 prefixcc,donto,http://reference.data.gov.au/def/ont/dataset#,canonical
 prefixcc,door,http://kannel.open.ac.uk/ontology#,canonical
+prefixcc,dop,https://w3id.org/dob/voc/prop#,canonical
 prefixcc,dossier,https://data.omgeving.vlaanderen.be/ns/dossier#,canonical
 prefixcc,dot,https://w3id.org/dot#,canonical
 prefixcc,dpc,http://hospee.org/ontologies/dpc/,canonical
@@ -730,6 +746,7 @@ prefixcc,ecoll,http://purl.org/ceu/eco/1.0#,canonical
 prefixcc,ecore,http://www.eclipse.org/emf/2002/Ecore#,canonical
 prefixcc,ecos,http://purl.org/ecos#,canonical
 prefixcc,ecowlim,http://ecowlim.tfri.gov.tw/lode/resource/,canonical
+prefixcc,ecp,http://www.ebu.ch/metadata/ontologies/ebucoreplus#,canonical
 prefixcc,ecpo,http://purl.org/ontology/ecpo#,canonical
 prefixcc,ecrm,http://erlangen-crm.org/current/,canonical
 prefixcc,ecs,http://rdf.ecs.soton.ac.uk/ontology/ecs#,canonical
@@ -742,6 +759,7 @@ prefixcc,edgarcik,http://edgarwrap.ontologycentral.com/cik/,canonical
 prefixcc,edm,http://www.europeana.eu/schemas/edm/,canonical
 prefixcc,edo,http://semanticweb.org/edo#,canonical
 prefixcc,edr,https://w3id.org/laas-iot/edr#,canonical
+prefixcc,edtf,http://id.loc.gov/datatypes/EDTFScheme/,canonical
 prefixcc,edu,https://schema.edu.ee/,canonical
 prefixcc,edupro,http://ns.inria.fr/semed/eduprogression#,canonical
 prefixcc,eem,http://purl.org/eem#,canonical
@@ -779,7 +797,7 @@ prefixcc,enhancer,http://stanbol.apache.org/ontology/enhancer/enhancer#,canonica
 prefixcc,ens,http://models.okkam.org/ENS-core-vocabulary.owl#,canonical
 prefixcc,ensembl,http://rdf.ebi.ac.uk/resource/ensembl/,canonical
 prefixcc,environ,http://eulersharp.sourceforge.net/2003/03swap/environment#,canonical
-prefixcc,envo,http://purl.obolibrary.org/obo/ZP_,namespace_alias
+prefixcc,envo,http://purl.obolibrary.org/obo/ZP_,canonical
 prefixcc,eo,http://purl.obolibrary.org/obo/EO_,canonical
 prefixcc,eol,http://purl.org/biodiversity/eol/,canonical
 prefixcc,ep,http://eprints.org/ontology/,namespace_alias
@@ -894,6 +912,7 @@ prefixcc,fernanda,http://fernanda.nl/,canonical
 prefixcc,fhir,http://hl7.org/fhir/,canonical
 prefixcc,fiaf,https://ontology.fiafcore.org/,canonical
 prefixcc,fibo,https://spec.edmcouncil.org/fibo/ontology/master/latest/,canonical
+prefixcc,fideo,http://purl.obolibrary.org/obo/FIDEO_,canonical
 prefixcc,figigii,http://www.omg.org/spec/FIGI/GlobalInstrumentIdentifiers/,canonical
 prefixcc,film,http://semantics.id/ns/example/film/,canonical
 prefixcc,fincaselaw,http://purl.org/finlex/schema/oikeus/,canonical
@@ -1030,7 +1049,7 @@ prefixcc,gfo,http://www.onto-med.de/ontologies/gfo.owl#,canonical
 prefixcc,gg,http://www.gemeentegeschiedenis.nl/gg-schema#,canonical
 prefixcc,ggbn,http://data.ggbn.org/schemas/ggbn/terms/,canonical
 prefixcc,ghga,http://w3id.org/ghga/,canonical
-prefixcc,gist,https://ontologies.semanticarts.com/o/gistCore#,canonical
+prefixcc,gist,http://ontologies.semanticarts.com/gist#,canonical
 prefixcc,giving,http://ontologi.es/giving#,canonical
 prefixcc,gl,http://schema.geolink.org/,canonical
 prefixcc,gldp,http://www.w3.org/ns/people#,canonical
@@ -1076,9 +1095,10 @@ prefixcc,grel,http://users.ugent.be/~bjdmeest/function/grel.ttl#,canonical
 prefixcc,gridworks,http://purl.org/net/opmv/types/gridworks#,canonical
 prefixcc,grs,http://www.georss.org/georss/,namespace_alias
 prefixcc,grscicoll,https://www.gbif.org/grscicoll/collection/,canonical
-prefixcc,gs1,http://gs1.org/voc/,canonical
+prefixcc,gs1,https://ref.gs1.org/voc/,canonical
 prefixcc,gso,http://www.w3.org/2006/gen/ont#,canonical
 prefixcc,gsp,http://www.opengis.net/ont/geosparql#,namespace_alias
+prefixcc,gsso,http://purl.obolibrary.org/obo/GSSO_,canonical
 prefixcc,gt,https://vocab.eccenca.com/geniustex/,canonical
 prefixcc,gtfs,http://vocab.gtfs.org/terms#,canonical
 prefixcc,gtm,https://www.goudatijdmachine.nl/def/,canonical
@@ -1217,7 +1237,7 @@ prefixcc,ino,http://purl.obolibrary.org/obo/INO_,canonical
 prefixcc,input,http://volt-name.space/vocab/input#,canonical
 prefixcc,insdc,http://ddbj.nig.ac.jp/ontologies/sequence#,canonical
 prefixcc,interop,http://www.w3.org/ns/solid/interop#,canonical
-prefixcc,interpro,http://purl.obolibrary.org/obo/IPR_,canonical
+prefixcc,interpro,https://www.ebi.ac.uk/interpro/entry/InterPro/,canonical
 prefixcc,interval,http://reference.data.gov.uk/def/intervals/,canonical
 prefixcc,intervals,http://reference.data.gov.uk/def/intervals/,namespace_alias
 prefixcc,into,https://app.korfin.de/ontology/into/,canonical
@@ -1312,6 +1332,7 @@ prefixcc,kpd,http://purl.org/kpd/,canonical
 prefixcc,ksam,http://kulturarvsdata.se/ksamsok#,namespace_alias
 prefixcc,ksamsok,http://kulturarvsdata.se/ksamsok#,namespace_alias
 prefixcc,kupkb,http://www.e-lico.eu/data/kupkb/,canonical
+prefixcc,kvasir,https://kvasir.discover.ilabt.imec.be/vocab#,canonical
 prefixcc,kw,http://kwantu.net/kw/,canonical
 prefixcc,kwijibo,http://kwijibo.talis.com/,canonical
 prefixcc,l2sp,http://www.linked2safety-project.eu/properties/,canonical
@@ -1320,6 +1341,7 @@ prefixcc,l4lod,http://ns.inria.fr/l4lod/v2/,canonical
 prefixcc,la,https://linked.art/ns/terms/,canonical
 prefixcc,laabs,http://dbpedia.org/resource/,namespace_alias
 prefixcc,label,http://purl.org/net/vocab/2004/03/label#,canonical
+prefixcc,labo,http://purl.obolibrary.org/obo/LABO_,canonical
 prefixcc,lado,http://archaeology.link/ontology#,canonical
 prefixcc,lang,http://ontologi.es/lang/core#,canonical
 prefixcc,language,http://id.loc.gov/vocabulary/iso639-1/,canonical
@@ -1402,6 +1424,7 @@ prefixcc,linkedmdb,http://data.linkedmdb.org/,canonical
 prefixcc,linkml,https://w3id.org/linkml/,canonical
 prefixcc,linkrel,https://www.w3.org/ns/iana/link-relations/relation#,namespace_alias
 prefixcc,lio,http://purl.org/net/lio#,canonical
+prefixcc,liph,https://gallosiciliani.unict.it/ns/lpont#,canonical
 prefixcc,lipro,http://purl.obolibrary.org/obo/LIPRO_,canonical
 prefixcc,lis,http://rds.posccaesar.org/ontology/lis14/rdl/,canonical
 prefixcc,list,http://www.w3.org/2000/10/swap/list#,canonical
@@ -1493,6 +1516,8 @@ prefixcc,maet,http://edg.topbraid.solutions/taxonomy/macroeconomics/,canonical
 prefixcc,mag,https://makg.org/property/,canonical
 prefixcc,magmardl,http://www.semanticweb.org/magma-core/rdl#,canonical
 prefixcc,magmauser,http://www.semanticweb.org/magma-core/user#,canonical
+prefixcc,maid,https://mutual-aid.app/ns/core#,canonical
+prefixcc,makeup,http://example.org/makeup#,canonical
 prefixcc,malaka,http://george.gr/,canonical
 prefixcc,malignneo,http://www.agfa.com/w3c/2009/malignantNeoplasm#,canonical
 prefixcc,mammal,http://lod.taxonconcept.org/ontology/p01/Mammalia/index.owl#,canonical
@@ -1509,6 +1534,7 @@ prefixcc,maroc,http://fr.dbpedia.org/page/Maroc/,canonical
 prefixcc,marshall,http://sites.google.com/site/xgmaitc/,canonical
 prefixcc,maso,http://securitytoolbox.appspot.com/MASO#,canonical
 prefixcc,master1,http://idl.u-grenoble3.fr/,canonical
+prefixcc,mat,http://purl.obolibrary.org/obo/MAT_,canonical
 prefixcc,math,http://www.w3.org/2000/10/swap/math#,canonical
 prefixcc,matmine,http://materialsmine.org/ns/,canonical
 prefixcc,matrycs,http://matrycs.com/,canonical
@@ -1531,6 +1557,7 @@ prefixcc,meat,http://example.com/,canonical
 prefixcc,meb,http://rdf.myexperiment.org/ontologies/base/,canonical
 prefixcc,media,http://search.yahoo.com/searchmonkey/media/,canonical
 prefixcc,medred,http://w3id.org/medred/medred#,canonical
+prefixcc,mee,http://www.w3.org/ns/pim/meeting#,canonical
 prefixcc,meeting,http://www.w3.org/2002/07/meeting#,canonical
 prefixcc,meetup,http://www.lotico.com/meetup/,canonical
 prefixcc,mei,http://www.music-encoding.org/ns/mei/,canonical
@@ -1608,6 +1635,7 @@ prefixcc,motogp,http://www.motogp.com/,canonical
 prefixcc,movie,http://data.linkedmdb.org/resource/movie/,canonical
 prefixcc,movieo,http://movie.com/ontology/,canonical
 prefixcc,mp,http://jicamaro.info/mp#,canonical
+prefixcc,mpath,http://purl.obolibrary.org/obo/MPATH_,canonical
 prefixcc,mpbv,http://meta-pfarrerbuch.evangelische-archive.de/vocabulary#,canonical
 prefixcc,mpeg7,http://rhizomik.net/ontologies/2005/03/Mpeg7-2001.owl#,canonical
 prefixcc,mpg123,https://devuan.net.br/wiki/mpg123/,canonical
@@ -1646,6 +1674,7 @@ prefixcc,myprefix,http://myprefix.org/,canonical
 prefixcc,myspace,http://purl.org/ontology/myspace#,canonical
 prefixcc,myspo,http://purl.org/ontology/myspace#,namespace_alias
 prefixcc,mysql,http://web-semantics.org/ns/mysql/,canonical
+prefixcc,nace2,http://data.europa.eu/ux2/nace2/,canonical
 prefixcc,nalt,https://lod.nal.usda.gov/nalt/,canonical
 prefixcc,name,http://example.org/name#,canonical
 prefixcc,namespaces,https://vg.no/,canonical
@@ -1734,6 +1763,7 @@ prefixcc,oac,https://w3id.org/oac#,canonical
 prefixcc,oad,http://lod.xdams.org/reload/oad/,canonical
 prefixcc,oae,http://www.ics.forth.gr/isl/oae/core#,canonical
 prefixcc,oan,http://data.lirmm.fr/ontologies/oan/,canonical
+prefixcc,oarcs,http://purl.obolibrary.org/obo/OARCS_,canonical
 prefixcc,oarj,http://opendepot.org/reference/linked/1.0/,canonical
 prefixcc,oat,http://openlinksw.com/schemas/oat/,canonical
 prefixcc,oauth,http://demiblog.org/vocab/oauth#,canonical
@@ -1815,6 +1845,7 @@ prefixcc,okkam,http://models.okkam.org/ENS-core-vocabulary#,canonical
 prefixcc,olac,http://www.language-archives.org/OLAC/1.0/,canonical
 prefixcc,olac11,http://www.language-archives.org/OLAC/1.1/,canonical
 prefixcc,olad,http://openlad.org/vocab#,canonical
+prefixcc,olatdv,http://purl.obolibrary.org/obo/OlatDv_,canonical
 prefixcc,olca,http://www.lingvoj.org/olca#,canonical
 prefixcc,olia,http://purl.org/olia/olia.owl#,canonical
 prefixcc,olias,http://purl.org/olia/system.owl#,namespace_alias
@@ -1828,6 +1859,7 @@ prefixcc,omc,http://purl.org/ontomedia/ext/common/bestiary#,canonical
 prefixcc,omdoc,http://omdoc.org/ontology/,canonical
 prefixcc,ome,http://purl.org/ontomedia/core/expression#,canonical
 prefixcc,omg,https://w3id.org/omg#,canonical
+prefixcc,omiabis,http://purl.obolibrary.org/obo/OMIABIS_,canonical
 prefixcc,omim,http://purl.bioontology.org/ontology/OMIM/,canonical
 prefixcc,omit,http://purl.obolibrary.org/obo/OMIT_,canonical
 prefixcc,oml,http://def.seegrid.csiro.au/ontology/om/om-lite#,canonical
@@ -1873,6 +1905,7 @@ prefixcc,opengov,http://www.w3.org/opengov#,canonical
 prefixcc,openlinks,http://www.openlinksw.com/schemas/virtrdf#,canonical
 prefixcc,opensearch,http://a9.com/-/spec/opensearch/1.1/,canonical
 prefixcc,openskos,http://openskos.org/xmlns#,canonical
+prefixcc,openwemi,https://ns.dublincore.org/openwemi/,canonical
 prefixcc,oper,http://sweet.jpl.nasa.gov/2.0/mathOperation.owl#,canonical
 prefixcc,opl,http://openlinksw.com/schema/attribution#,canonical
 prefixcc,oplacl,http://www.openlinksw.com/ontology/acl#,canonical
@@ -1990,8 +2023,8 @@ prefixcc,pat,http://purl.org/hpi/patchr#,canonical
 prefixcc,pato,http://purl.obolibrary.org/obo/,namespace_alias
 prefixcc,pattern,http://www.essepuntato.it/2008/12/pattern#,canonical
 prefixcc,pav,http://purl.org/pav/,canonical
-prefixcc,pay,http://reference.data.gov.uk/def/payment#,namespace_alias
-prefixcc,payment,http://reference.data.gov.uk/def/payment#,canonical
+prefixcc,pay,http://reference.data.gov.uk/def/payment#,canonical
+prefixcc,payment,http://reference.data.gov.uk/def/payment#,namespace_alias
 prefixcc,pbac,https://w3id.org/pbac#,canonical
 prefixcc,pbo,http://purl.org/ontology/pbo/core#,canonical
 prefixcc,pbody,http://reference.data.gov.uk/def/public-body/,canonical
@@ -2149,6 +2182,7 @@ prefixcc,ps,https://w3id.org/payswarm#,canonical
 prefixcc,psdo,http://purl.obolibrary.org/obo/PSDO_,canonical
 prefixcc,psh,http://ns.inria.fr/probabilistic-shacl/,canonical
 prefixcc,psm,https://paul.ti.rw.fau.de/~jo00defe/ont/psm#,canonical
+prefixcc,psn,https://purl.org/psn/vocab#,canonical
 prefixcc,pso,http://purl.org/spar/pso/,canonical
 prefixcc,psv,http://www.wikidata.org/prop/statement/value/,canonical
 prefixcc,psych,http://purl.org/vocab/psychometric-profile/,canonical
@@ -2209,6 +2243,7 @@ prefixcc,raul,http://vocab.deri.ie/raul#,canonical
 prefixcc,raum,https://terminology.fraunhofer.de/voc/raum#,canonical
 prefixcc,rb,https://w3id.org/riverbench/schema/metadata#,canonical
 prefixcc,rbdoc,https://w3id.org/riverbench/schema/documentation#,canonical
+prefixcc,rbo,http://purl.obolibrary.org/obo/RBO_,canonical
 prefixcc,rc,https://w3id.org/rc#,canonical
 prefixcc,rcgs,https://collection.rcgs.jp/terms/,canonical
 prefixcc,rda,http://www.rdaregistry.info/,canonical
@@ -2310,6 +2345,7 @@ prefixcc,rdfa,http://www.w3.org/ns/rdfa#,canonical
 prefixcc,rdfdata,http://rdf.data-vocabulary.org/rdf.xml#,canonical
 prefixcc,rdfdf,http://www.openlinksw.com/virtrdf-data-formats#,canonical
 prefixcc,rdfg,http://www.w3.org/2004/03/trix/rdfg-1/,canonical
+prefixcc,rdfl,https://w3id.org/rdf-lens/ontology#,canonical
 prefixcc,rdfp,https://w3id.org/rdfp/,canonical
 prefixcc,rdfs,http://www.w3.org/2000/01/rdf-schema#,canonical
 prefixcc,rdfsharp,https://rdfsharp.codeplex.com/,canonical
@@ -2364,6 +2400,7 @@ prefixcc,rm,http://jazz.net/ns/rm#,canonical
 prefixcc,rml,http://w3id.org/rml/,canonical
 prefixcc,rmlt,http://semweb.mmlab.be/ns/rml-target#,canonical
 prefixcc,rmo,http://eatld.et.tu-dresden.de/rmo#,canonical
+prefixcc,rnao,http://purl.obolibrary.org/obo/RNAO_,canonical
 prefixcc,rnce,https://data.cultureelerfgoed.nl/id/rnce#,canonical
 prefixcc,rnews,http://iptc.org/std/rNews/2011-10-07#,canonical
 prefixcc,ro,http://purl.org/wf4ever/ro#,canonical
@@ -2455,6 +2492,7 @@ prefixcc,sc,http://purl.org/science/owl/sciencecommons/,canonical
 prefixcc,scco,http://rdf.ebi.ac.uk/terms/surechembl#,canonical
 prefixcc,scdo,http://purl.obolibrary.org/obo/SCDO_,canonical
 prefixcc,schema,http://schema.org/,canonical
+prefixcc,schemas,https://schema.org/,namespace_alias
 prefixcc,scho,http://www.scholarlydata.org/ontology/conference-ontology.owl#,canonical
 prefixcc,schoi,https://w3id.org/scholarlydata/ontology/indicators-ontology.owl#,canonical
 prefixcc,scholl,http://menemeneml.com/school#,canonical
@@ -2563,6 +2601,7 @@ prefixcc,skosthes,http://purl.org/iso25964/skos-thes#,namespace_alias
 prefixcc,skosxl,http://www.w3.org/2008/05/skos-xl#,canonical
 prefixcc,sl,http://www.semanlink.net/2001/00/semanlink-schema#,canonical
 prefixcc,slm,http://urn.fi/URN:NBN:fi:au:slm:,canonical
+prefixcc,slso,http://purl.obolibrary.org/obo/SLSO_,canonical
 prefixcc,sm,http://topbraid.org/sparqlmotion#,canonical
 prefixcc,smartapi,http://smart-api.io/ontology/1.0/smartapi#,canonical
 prefixcc,smf,http://topbraid.org/sparqlmotionfunctions#,canonical
@@ -2944,6 +2983,7 @@ prefixcc,test2,http://this.invalid/test2#,canonical
 prefixcc,text,http://jena.apache.org/text#,canonical
 prefixcc,textgrid,https://textgridrep.org/,canonical
 prefixcc,tg,https://triplydb.com/Triply/tg/def/,canonical
+prefixcc,tgc,http://www.hds.utc.fr/tg#,canonical
 prefixcc,tgm,http://id.loc.gov/vocabulary/graphicMaterials/,canonical
 prefixcc,tgma,http://purl.obolibrary.org/obo/TGMA_,canonical
 prefixcc,tgn,http://vocab.getty.edu/tgn/,canonical
@@ -2971,6 +3011,7 @@ prefixcc,toaru,https://metadata.moe/toaru-sparql/elements/,canonical
 prefixcc,toby,http://tobyinkster.co.uk/#,canonical
 prefixcc,top,http://w3id.org/topologicpy#,canonical
 prefixcc,topo,http://data.ign.fr/def/topo#,canonical
+prefixcc,tops,http://www.topbraid.org/tops#,canonical
 prefixcc,tosh,http://topbraid.org/tosh#,canonical
 prefixcc,tp,https://triplydb.com/Triply/tp/def/,canonical
 prefixcc,tr,http://www.thomsonreuters.com/,canonical
@@ -3057,6 +3098,7 @@ prefixcc,va,http://code-research.eu/ontology/visual-analytics#,canonical
 prefixcc,vacseen1,http://www.semanticweb.org/parthasb/ontologies/2014/6/vacseen1/,canonical
 prefixcc,vaem,http://www.linkedmodel.org/schema/vaem#,canonical
 prefixcc,vag,http://www.essepuntato.it/2013/10/vagueness/,canonical
+prefixcc,vair,https://w3id.org/vair#,canonical
 prefixcc,value,http://gfgfd.vs/,canonical
 prefixcc,valueflows,https://w3id.org/valueflows/,canonical
 prefixcc,vam,http://www.metmuseum.org/,canonical
@@ -3122,6 +3164,7 @@ prefixcc,vr,https://www.w3.org/2018/credentials/v1/,canonical
 prefixcc,vra,http://purl.org/vra/,canonical
 prefixcc,vrank,http://purl.org/voc/vrank#,canonical
 prefixcc,vs,http://www.w3.org/2003/06/sw-vocab-status/ns#,canonical
+prefixcc,vsao,http://purl.obolibrary.org/obo/VSAO_,canonical
 prefixcc,vsearch,http://vocab.sti2.at/vsearch#,canonical
 prefixcc,vso,http://purl.org/vso/ns#,canonical
 prefixcc,vsr,http://purl.org/twc/vocab/vsr#,canonical
@@ -3131,6 +3174,7 @@ prefixcc,vsto,http://escience.rpi.edu/ontology/vsto/2/0/vsto.owl#,canonical
 prefixcc,vstoi,http://hadatac.org/ont/vstoi#,canonical
 prefixcc,vsw,http://verticalsearchworks.com/ontology/,canonical
 prefixcc,vsws,http://verticalsearchworks.com/ontology/synset#,canonical
+prefixcc,vt,http://purl.obolibrary.org/obo/VT_,canonical
 prefixcc,vto,http://purl.obolibrary.org/obo/VTO_,canonical
 prefixcc,vvo,http://purl.org/vvo/ns#,canonical
 prefixcc,w3,http://www.w3.org/,canonical
@@ -3226,6 +3270,7 @@ prefixcc,wscaim,http://www.openk.org/wscaim.owl#,namespace_alias
 prefixcc,wsdl,http://www.w3.org/ns/wsdl-rdf#,canonical
 prefixcc,wsl,http://www.wsmo.org/ns/wsmo-lite#,namespace_alias
 prefixcc,wv,http://vocab.org/waiver/terms/,canonical
+prefixcc,xao,http://purl.obolibrary.org/obo/XAO_,canonical
 prefixcc,xapi,https://w3id.org/xapi/ontology#,canonical
 prefixcc,xbrli,http://www.xbrl.org/2003/instance#,canonical
 prefixcc,xbrll,https://w3id.org/vocab/xbrll#,canonical

--- a/src/prefixmaps/data/w3id.csv
+++ b/src/prefixmaps/data/w3id.csv
@@ -58,6 +58,7 @@ w3id,annett-o,https://w3id.org/annett-o/,canonical
 w3id,aoi,https://w3id.org/aoi/,canonical
 w3id,APD,https://w3id.org/APD/,canonical
 w3id,apn,https://w3id.org/apn/,canonical
+w3id,APTO,https://w3id.org/APTO/,canonical
 w3id,aqfo,https://w3id.org/aqfo/,canonical
 w3id,arco,https://w3id.org/arco/,canonical
 w3id,ardo,https://w3id.org/ardo/,canonical
@@ -67,6 +68,7 @@ w3id,arm,https://w3id.org/arm/,canonical
 w3id,arp,https://w3id.org/arp/,canonical
 w3id,art,https://w3id.org/art/,canonical
 w3id,arto,https://w3id.org/arto/,canonical
+w3id,aruna,https://w3id.org/aruna/,canonical
 w3id,asbingowl,https://w3id.org/asbingowl/,canonical
 w3id,asdkb,https://w3id.org/asdkb/,canonical
 w3id,asfe,https://w3id.org/asfe/,canonical
@@ -120,6 +122,8 @@ w3id,bloxberg,https://w3id.org/bloxberg/,canonical
 w3id,bmat,https://w3id.org/bmat/,canonical
 w3id,BMO,https://w3id.org/BMO/,canonical
 w3id,bmontology,https://w3id.org/bmontology/,canonical
+w3id,bmp,https://w3id.org/bmp/,canonical
+w3id,bog,https://w3id.org/bog/,canonical
 w3id,book,https://w3id.org/book/,canonical
 w3id,bop,https://w3id.org/bop/,canonical
 w3id,bot,https://w3id.org/bot/,canonical
@@ -160,6 +164,7 @@ w3id,cerif,https://w3id.org/cerif/,canonical
 w3id,cerrotti,https://w3id.org/cerrotti/,canonical
 w3id,certainty_nanopubs,https://w3id.org/certainty_nanopubs/,canonical
 w3id,cevo,https://w3id.org/cevo/,canonical
+w3id,cff,https://w3id.org/cff/,canonical
 w3id,chainpoint,https://w3id.org/chainpoint/,canonical
 w3id,chalkgrp,https://w3id.org/chalkgrp/,canonical
 w3id,character-computing,https://w3id.org/character-computing/,canonical
@@ -187,6 +192,7 @@ w3id,cld,https://w3id.org/cld/,canonical
 w3id,clinga,https://w3id.org/clinga/,canonical
 w3id,clipc,https://w3id.org/clipc/,canonical
 w3id,clodg,https://w3id.org/clodg/,canonical
+w3id,cluedo4KG,https://w3id.org/cluedo4KG/,canonical
 w3id,cmd,https://w3id.org/cmd/,canonical
 w3id,CMECS,https://w3id.org/CMECS/,canonical
 w3id,cmip6dr,https://w3id.org/cmip6dr/,canonical
@@ -197,6 +203,7 @@ w3id,cntf,https://w3id.org/cntf/,canonical
 w3id,cocoon,https://w3id.org/cocoon/,canonical
 w3id,codata,https://w3id.org/codata/,canonical
 w3id,codemeta,https://w3id.org/codemeta/,canonical
+w3id,codemetasoft,https://w3id.org/codemetasoft/,canonical
 w3id,codo,https://w3id.org/codo/,canonical
 w3id,ColActDOnt,https://w3id.org/ColActDOnt/,canonical
 w3id,combining-linking-techniques,https://w3id.org/combining-linking-techniques/,canonical
@@ -251,6 +258,7 @@ w3id,d2kg,https://w3id.org/d2kg/,canonical
 w3id,d2s,https://w3id.org/d2s/,canonical
 w3id,dao,https://w3id.org/dao/,canonical
 w3id,daselab,https://w3id.org/daselab/,canonical
+w3id,data-fw,https://w3id.org/data-fw/,canonical
 w3id,Data-Maturity,https://w3id.org/Data-Maturity/,canonical
 w3id,data2services,https://w3id.org/data2services/,canonical
 w3id,datamart,https://w3id.org/datamart/,canonical
@@ -268,6 +276,7 @@ w3id,dco,https://w3id.org/dco/,canonical
 w3id,DCRI-ont,https://w3id.org/DCRI-ont/,canonical
 w3id,DCRI-ont-spe,https://w3id.org/DCRI-ont-spe/,canonical
 w3id,DCRI-voc,https://w3id.org/DCRI-voc/,canonical
+w3id,dcs-se-extension,https://w3id.org/dcs-se-extension/,canonical
 w3id,dcso,https://w3id.org/dcso/,canonical
 w3id,dcx,https://w3id.org/dcx/,canonical
 w3id,ddb,https://w3id.org/ddb/,canonical
@@ -285,6 +294,7 @@ w3id,devops-infra,https://w3id.org/devops-infra/,canonical
 w3id,dfc,https://w3id.org/dfc/,canonical
 w3id,dfd,https://w3id.org/dfd/,canonical
 w3id,DFDP,https://w3id.org/DFDP/,canonical
+w3id,dfgfo,https://w3id.org/dfgfo/,canonical
 w3id,dfo,https://w3id.org/dfo/,canonical
 w3id,dgarijo,https://w3id.org/dgarijo/,canonical
 w3id,dgassist,https://w3id.org/dgassist/,canonical
@@ -313,15 +323,18 @@ w3id,DLTOntology,https://w3id.org/DLTOntology/,canonical
 w3id,dm4eepsa,https://w3id.org/dm4eepsa/,canonical
 w3id,dmi,https://w3id.org/dmi/,canonical
 w3id,dmo,https://w3id.org/dmo/,canonical
+w3id,dmpqv,https://w3id.org/dmpqv/,canonical
 w3id,dmscope-fdp,https://w3id.org/dmscope-fdp/,canonical
 w3id,DnD5eCharacter,https://w3id.org/DnD5eCharacter/,canonical
 w3id,do4kg,https://w3id.org/do4kg/,canonical
+w3id,dob,https://w3id.org/dob/,canonical
 w3id,DockerPedia,https://w3id.org/DockerPedia/,canonical
 w3id,docmaps,https://w3id.org/docmaps/,canonical
 w3id,documents,https://w3id.org/documents/,canonical
 w3id,DOLCE,https://w3id.org/DOLCE/,canonical
 w3id,dosdp,https://w3id.org/dosdp/,canonical
 w3id,dot,https://w3id.org/dot/,canonical
+w3id,doves,https://w3id.org/doves/,canonical
 w3id,dpcat,https://w3id.org/dpcat/,canonical
 w3id,dpp,https://w3id.org/dpp/,canonical
 w3id,dppo,https://w3id.org/dppo/,canonical
@@ -331,6 +344,7 @@ w3id,dqts,https://w3id.org/dqts/,canonical
 w3id,dream-lab,https://w3id.org/dream-lab/,canonical
 w3id,drinventor,https://w3id.org/drinventor/,canonical
 w3id,drone,https://w3id.org/drone/,canonical
+w3id,drp,https://w3id.org/drp/,canonical
 w3id,dsa,https://w3id.org/dsa/,canonical
 w3id,dsd,https://w3id.org/dsd/,canonical
 w3id,dso,https://w3id.org/dso/,canonical
@@ -386,6 +400,7 @@ w3id,emmo-maeo,https://w3id.org/emmo-maeo/,canonical
 w3id,empathi,https://w3id.org/empathi/,canonical
 w3id,encode,https://w3id.org/encode/,canonical
 w3id,EnergyInformationModel,https://w3id.org/EnergyInformationModel/,canonical
+w3id,enershare,https://w3id.org/enershare/,canonical
 w3id,engrd,https://w3id.org/engrd/,canonical
 w3id,enigma,https://w3id.org/enigma/,canonical
 w3id,env,https://w3id.org/env/,canonical
@@ -396,12 +411,14 @@ w3id,ep-plan,https://w3id.org/ep-plan/,canonical
 w3id,epont,https://w3id.org/epont/,canonical
 w3id,epsilonitalia,https://w3id.org/epsilonitalia/,canonical
 w3id,ereefs,https://w3id.org/ereefs/,canonical
+w3id,ERKNet,https://w3id.org/ERKNet/,canonical
 w3id,erkreg-fdp,https://w3id.org/erkreg-fdp/,canonical
 w3id,ern-euro-nmd-fdp,https://w3id.org/ern-euro-nmd-fdp/,canonical
 w3id,esbm,https://w3id.org/esbm/,canonical
 w3id,esim,https://w3id.org/esim/,canonical
 w3id,ESO,https://w3id.org/ESO/,canonical
 w3id,esw,https://w3id.org/esw/,canonical
+w3id,etap,https://w3id.org/etap/,canonical
 w3id,EUREF-HDC,https://w3id.org/EUREF-HDC/,canonical
 w3id,euro-nmd-kpis,https://w3id.org/euro-nmd-kpis/,canonical
 w3id,EUTaxO,https://w3id.org/EUTaxO/,canonical
@@ -437,6 +454,7 @@ w3id,FAIR_eva,https://w3id.org/FAIR_eva/,canonical
 w3id,FAIR_Evaluator,https://w3id.org/FAIR_Evaluator/,canonical
 w3id,FAIR_Tests,https://w3id.org/FAIR_Tests/,canonical
 w3id,FAIR_Training_LDP,https://w3id.org/FAIR_Training_LDP/,canonical
+w3id,fairchecker,https://w3id.org/fairchecker/,canonical
 w3id,faircookbook,https://w3id.org/faircookbook/,canonical
 w3id,fairjupyter,https://w3id.org/fairjupyter/,canonical
 w3id,FAIROS,https://w3id.org/FAIROS/,canonical
@@ -485,6 +503,7 @@ w3id,fst,https://w3id.org/fst/,canonical
 w3id,ftm,https://w3id.org/ftm/,canonical
 w3id,FTP,https://w3id.org/FTP/,canonical
 w3id,ftr,https://w3id.org/ftr/,canonical
+w3id,fuel,https://w3id.org/fuel/,canonical
 w3id,function,https://w3id.org/function/,canonical
 w3id,fuskg,https://w3id.org/fuskg/,canonical
 w3id,g0v,https://w3id.org/g0v/,canonical
@@ -493,6 +512,8 @@ w3id,gaia-x,https://w3id.org/gaia-x/,canonical
 w3id,games,https://w3id.org/games/,canonical
 w3id,gas,https://w3id.org/gas/,canonical
 w3id,GasInformationModel,https://w3id.org/GasInformationModel/,canonical
+w3id,GayCities,https://w3id.org/GayCities/,canonical
+w3id,GayLesbianBisexualTVCharacters,https://w3id.org/GayLesbianBisexualTVCharacters/,canonical
 w3id,gba,https://w3id.org/gba/,canonical
 w3id,gbo,https://w3id.org/gbo/,canonical
 w3id,GConsent,https://w3id.org/GConsent/,canonical
@@ -524,6 +545,7 @@ w3id,gom,https://w3id.org/gom/,canonical
 w3id,gpo,https://w3id.org/gpo/,canonical
 w3id,gptto,https://w3id.org/gptto/,canonical
 w3id,Green-AI-Ontology,https://w3id.org/Green-AI-Ontology/,canonical
+w3id,Greens,https://w3id.org/Greens/,canonical
 w3id,greycite,https://w3id.org/greycite/,canonical
 w3id,gso,https://w3id.org/gso/,canonical
 w3id,gub,https://w3id.org/gub/,canonical
@@ -540,6 +562,7 @@ w3id,hclscg,https://w3id.org/hclscg/,canonical
 w3id,hdgi,https://w3id.org/hdgi/,canonical
 w3id,hdruk,https://w3id.org/hdruk/,canonical
 w3id,health-schemas,https://w3id.org/health-schemas/,canonical
+w3id,hefquin,https://w3id.org/hefquin/,canonical
 w3id,helis,https://w3id.org/helis/,canonical
 w3id,hero,https://w3id.org/hero/,canonical
 w3id,HHT,https://w3id.org/HHT/,canonical
@@ -587,6 +610,7 @@ w3id,ifc,https://w3id.org/ifc/,canonical
 w3id,ifcc,https://w3id.org/ifcc/,canonical
 w3id,ifcp,https://w3id.org/ifcp/,canonical
 w3id,iicongraph,https://w3id.org/iicongraph/,canonical
+w3id,IIoT,https://w3id.org/IIoT/,canonical
 w3id,iliad,https://w3id.org/iliad/,canonical
 w3id,illusnip,https://w3id.org/illusnip/,canonical
 w3id,imec,https://w3id.org/imec/,canonical
@@ -597,13 +621,13 @@ w3id,indonesia-history,https://w3id.org/indonesia-history/,canonical
 w3id,inesdata,https://w3id.org/inesdata/,canonical
 w3id,inmevo,https://w3id.org/inmevo/,canonical
 w3id,inrupt,https://w3id.org/inrupt/,canonical
+w3id,inspireOnts,https://w3id.org/inspireOnts/,canonical
 w3id,instructie,https://w3id.org/instructie/,canonical
 w3id,interactions,https://w3id.org/interactions/,canonical
 w3id,interont,https://w3id.org/interont/,canonical
 w3id,ioc,https://w3id.org/ioc/,canonical
 w3id,iomust,https://w3id.org/iomust/,canonical
 w3id,iot,https://w3id.org/iot/,canonical
-w3id,iot-tta,https://w3id.org/iot-tta/,canonical
 w3id,iotd,https://w3id.org/iotd/,canonical
 w3id,iotf,https://w3id.org/iotf/,canonical
 w3id,ipsoeu,https://w3id.org/ipsoeu/,canonical
@@ -620,6 +644,7 @@ w3id,italia,https://w3id.org/italia/,canonical
 w3id,itil,https://w3id.org/itil/,canonical
 w3id,ixo,https://w3id.org/ixo/,canonical
 w3id,JazzOntology,https://w3id.org/JazzOntology/,canonical
+w3id,jelly,https://w3id.org/jelly/,canonical
 w3id,jhercher,https://w3id.org/jhercher/,canonical
 w3id,jicamarca,https://w3id.org/jicamarca/,canonical
 w3id,jp-cos,https://w3id.org/jp-cos/,canonical
@@ -649,10 +674,13 @@ w3id,kouigenjimonogatari,https://w3id.org/kouigenjimonogatari/,canonical
 w3id,kpionto,https://w3id.org/kpionto/,canonical
 w3id,kpxl,https://w3id.org/kpxl/,canonical
 w3id,ksa,https://w3id.org/ksa/,canonical
+w3id,kw,https://w3id.org/kw/,canonical
 w3id,kxu,https://w3id.org/kxu/,canonical
 w3id,l4dr,https://w3id.org/l4dr/,canonical
 w3id,la,https://w3id.org/la/,canonical
 w3id,laas-iot,https://w3id.org/laas-iot/,canonical
+w3id,laderr,https://w3id.org/laderr/,canonical
+w3id,lara,https://w3id.org/lara/,canonical
 w3id,latuli,https://w3id.org/latuli/,canonical
 w3id,launuts,https://w3id.org/launuts/,canonical
 w3id,lbd,https://w3id.org/lbd/,canonical
@@ -710,8 +738,10 @@ w3id,lustre,https://w3id.org/lustre/,canonical
 w3id,Mach30,https://w3id.org/Mach30/,canonical
 w3id,madmp,https://w3id.org/madmp/,canonical
 w3id,makg,https://w3id.org/makg/,canonical
+w3id,malke,https://w3id.org/malke/,canonical
 w3id,mapvowl,https://w3id.org/mapvowl/,canonical
 w3id,mare,https://w3id.org/mare/,canonical
+w3id,matolab,https://w3id.org/matolab/,canonical
 w3id,mbl,https://w3id.org/mbl/,canonical
 w3id,mdc-docs,https://w3id.org/mdc-docs/,canonical
 w3id,mdo,https://w3id.org/mdo/,canonical
@@ -729,6 +759,7 @@ w3id,metamodeling,https://w3id.org/metamodeling/,canonical
 w3id,mex,https://w3id.org/mex/,canonical
 w3id,mgkb,https://w3id.org/mgkb/,canonical
 w3id,mica,https://w3id.org/mica/,canonical
+w3id,micoll-map,https://w3id.org/micoll-map/,canonical
 w3id,midas-catalog,https://w3id.org/midas-catalog/,canonical
 w3id,midas-metadata,https://w3id.org/midas-metadata/,canonical
 w3id,mifesto,https://w3id.org/mifesto/,canonical
@@ -761,6 +792,7 @@ w3id,montolo,https://w3id.org/montolo/,canonical
 w3id,moody,https://w3id.org/moody/,canonical
 w3id,moont,https://w3id.org/moont/,canonical
 w3id,MoRe-SFB1475,https://w3id.org/MoRe-SFB1475/,canonical
+w3id,moro,https://w3id.org/moro/,canonical
 w3id,mosaic,https://w3id.org/mosaic/,canonical
 w3id,mpilhlt,https://w3id.org/mpilhlt/,canonical
 w3id,MQIO,https://w3id.org/MQIO/,canonical
@@ -782,6 +814,7 @@ w3id,music-circle,https://w3id.org/music-circle/,canonical
 w3id,musico,https://w3id.org/musico/,canonical
 w3id,musow,https://w3id.org/musow/,canonical
 w3id,n2t,https://w3id.org/n2t/,canonical
+w3id,nanolinks,https://w3id.org/nanolinks/,canonical
 w3id,nanoweb,https://w3id.org/nanoweb/,canonical
 w3id,national-ocean-council,https://w3id.org/national-ocean-council/,canonical
 w3id,navigation_menu,https://w3id.org/navigation_menu/,canonical
@@ -826,12 +859,15 @@ w3id,obpa,https://w3id.org/obpa/,canonical
 w3id,obpd,https://w3id.org/obpd/,canonical
 w3id,oc,https://w3id.org/oc/,canonical
 w3id,occ,https://w3id.org/occ/,canonical
+w3id,ocedo,https://w3id.org/ocedo/,canonical
 w3id,OCL-SOP,https://w3id.org/OCL-SOP/,canonical
 w3id,ocqa,https://w3id.org/ocqa/,canonical
 w3id,ocs,https://w3id.org/ocs/,canonical
+w3id,ocsm,https://w3id.org/ocsm/,canonical
 w3id,ODE_AM,https://w3id.org/ODE_AM/,canonical
 w3id,odi,https://w3id.org/odi/,canonical
 w3id,odissei,https://w3id.org/odissei/,canonical
+w3id,ods,https://w3id.org/ods/,canonical
 w3id,oebDataFormats,https://w3id.org/oebDataFormats/,canonical
 w3id,oebDatasets,https://w3id.org/oebDatasets/,canonical
 w3id,oerbase,https://w3id.org/oerbase/,canonical
@@ -851,6 +887,7 @@ w3id,onderwijs-vlaanderen,https://w3id.org/onderwijs-vlaanderen/,canonical
 w3id,onto4drone,https://w3id.org/onto4drone/,canonical
 w3id,ontobio,https://w3id.org/ontobio/,canonical
 w3id,ontoboldt,https://w3id.org/ontoboldt/,canonical
+w3id,ontobpr,https://w3id.org/ontobpr/,canonical
 w3id,ontocis,https://w3id.org/ontocis/,canonical
 w3id,ontocity,https://w3id.org/ontocity/,canonical
 w3id,OntoDM-core-extended,https://w3id.org/OntoDM-core-extended/,canonical
@@ -861,9 +898,11 @@ w3id,ontoeng,https://w3id.org/ontoeng/,canonical
 w3id,OntoExhibit,https://w3id.org/OntoExhibit/,canonical
 w3id,ontoexp,https://w3id.org/ontoexp/,canonical
 w3id,ontofnct,https://w3id.org/ontofnct/,canonical
+w3id,ontogen,https://w3id.org/ontogen/,canonical
 w3id,ontogpt,https://w3id.org/ontogpt/,canonical
 w3id,OntoGraphDB,https://w3id.org/OntoGraphDB/,canonical
 w3id,ontoim,https://w3id.org/ontoim/,canonical
+w3id,ontoindire,https://w3id.org/ontoindire/,canonical
 w3id,ontolink,https://w3id.org/ontolink/,canonical
 w3id,ontomlc,https://w3id.org/ontomlc/,canonical
 w3id,ontoology,https://w3id.org/ontoology/,canonical
@@ -884,6 +923,7 @@ w3id,OOSMP,https://w3id.org/OOSMP/,canonical
 w3id,ooxml,https://w3id.org/ooxml/,canonical
 w3id,openbadges,https://w3id.org/openbadges/,canonical
 w3id,opencare,https://w3id.org/opencare/,canonical
+w3id,openebench,https://w3id.org/openebench/,canonical
 w3id,openeduhub,https://w3id.org/openeduhub/,canonical
 w3id,openfooddata,https://w3id.org/openfooddata/,canonical
 w3id,opengtsc,https://w3id.org/opengtsc/,canonical
@@ -904,6 +944,7 @@ w3id,orphadata,https://w3id.org/orphadata/,canonical
 w3id,OSCD,https://w3id.org/OSCD/,canonical
 w3id,osdu,https://w3id.org/osdu/,canonical
 w3id,oseg,https://w3id.org/oseg/,canonical
+w3id,oso,https://w3id.org/oso/,canonical
 w3id,ost,https://w3id.org/ost/,canonical
 w3id,ovama-proms,https://w3id.org/ovama-proms/,canonical
 w3id,OWLChangeOntology,https://w3id.org/OWLChangeOntology/,canonical
@@ -932,11 +973,13 @@ w3id,pet,https://w3id.org/pet/,canonical
 w3id,pfeepsa,https://w3id.org/pfeepsa/,canonical
 w3id,pghdprovo,https://w3id.org/pghdprovo/,canonical
 w3id,pgp,https://w3id.org/pgp/,canonical
+w3id,pharmaccess,https://w3id.org/pharmaccess/,canonical
 w3id,phuse,https://w3id.org/phuse/,canonical
 w3id,phydit,https://w3id.org/phydit/,canonical
 w3id,pizza2,https://w3id.org/pizza2/,canonical
 w3id,pkd4wod,https://w3id.org/pkd4wod/,canonical
 w3id,pkg,https://w3id.org/pkg/,canonical
+w3id,pko,https://w3id.org/pko/,canonical
 w3id,plasma,https://w3id.org/plasma/,canonical
 w3id,platoon,https://w3id.org/platoon/,canonical
 w3id,plattform-i40,https://w3id.org/plattform-i40/,canonical
@@ -986,6 +1029,7 @@ w3id,rbeepsa,https://w3id.org/rbeepsa/,canonical
 w3id,rc,https://w3id.org/rc/,canonical
 w3id,rd-fairmetrics,https://w3id.org/rd-fairmetrics/,canonical
 w3id,rd-fairness-tests,https://w3id.org/rd-fairness-tests/,canonical
+w3id,rdf-connect,https://w3id.org/rdf-connect/,canonical
 w3id,rdf-spreadsheet,https://w3id.org/rdf-spreadsheet/,canonical
 w3id,rdfbones,https://w3id.org/rdfbones/,canonical
 w3id,rdfp,https://w3id.org/rdfp/,canonical
@@ -1004,6 +1048,7 @@ w3id,requirement-ontology,https://w3id.org/requirement-ontology/,canonical
 w3id,research-technology-readiness-levels,https://w3id.org/research-technology-readiness-levels/,canonical
 w3id,reseo,https://w3id.org/reseo/,canonical
 w3id,reshare,https://w3id.org/reshare/,canonical
+w3id,resiliont,https://w3id.org/resiliont/,canonical
 w3id,resource2vec,https://w3id.org/resource2vec/,canonical
 w3id,respond,https://w3id.org/respond/,canonical
 w3id,resriskonto,https://w3id.org/resriskonto/,canonical
@@ -1013,6 +1058,7 @@ w3id,rgom,https://w3id.org/rgom/,canonical
 w3id,rhonda,https://w3id.org/rhonda/,canonical
 w3id,ride2rail,https://w3id.org/ride2rail/,canonical
 w3id,rights-vocabulary,https://w3id.org/rights-vocabulary/,canonical
+w3id,rio,https://w3id.org/rio/,canonical
 w3id,risk,https://w3id.org/risk/,canonical
 w3id,riskman,https://w3id.org/riskman/,canonical
 w3id,riskonto,https://w3id.org/riskonto/,canonical
@@ -1060,6 +1106,7 @@ w3id,se,https://w3id.org/se/,canonical
 w3id,sea-lod,https://w3id.org/sea-lod/,canonical
 w3id,SeaChange,https://w3id.org/SeaChange/,canonical
 w3id,seas,https://w3id.org/seas/,canonical
+w3id,sebi,https://w3id.org/sebi/,canonical
 w3id,security,https://w3id.org/security/,canonical
 w3id,sedimark,https://w3id.org/sedimark/,canonical
 w3id,segittur,https://w3id.org/segittur/,canonical
@@ -1099,6 +1146,7 @@ w3id,situannotate,https://w3id.org/situannotate/,canonical
 w3id,sketup,https://w3id.org/sketup/,canonical
 w3id,sketx,https://w3id.org/sketx/,canonical
 w3id,skg,https://w3id.org/skg/,canonical
+w3id,skg-if,https://w3id.org/skg-if/,canonical
 w3id,skgo,https://w3id.org/skgo/,canonical
 w3id,skz,https://w3id.org/skz/,canonical
 w3id,slo,https://w3id.org/slo/,canonical
@@ -1106,6 +1154,7 @@ w3id,sm,https://w3id.org/sm/,canonical
 w3id,smarcql,https://w3id.org/smarcql/,canonical
 w3id,smart-sensing,https://w3id.org/smart-sensing/,canonical
 w3id,smartcare-fdp,https://w3id.org/smartcare-fdp/,canonical
+w3id,smartedge,https://w3id.org/smartedge/,canonical
 w3id,smartenvironment,https://w3id.org/smartenvironment/,canonical
 w3id,smartflanders,https://w3id.org/smartflanders/,canonical
 w3id,smetzger,https://w3id.org/smetzger/,canonical
@@ -1172,6 +1221,7 @@ w3id,t-sita,https://w3id.org/t-sita/,canonical
 w3id,tangpoem,https://w3id.org/tangpoem/,canonical
 w3id,tao,https://w3id.org/tao/,canonical
 w3id,tate-skos,https://w3id.org/tate-skos/,canonical
+w3id,tav,https://w3id.org/tav/,canonical
 w3id,tawc,https://w3id.org/tawc/,canonical
 w3id,td,https://w3id.org/td/,canonical
 w3id,tdy,https://w3id.org/tdy/,canonical
@@ -1183,6 +1233,7 @@ w3id,tern,https://w3id.org/tern/,canonical
 w3id,terror,https://w3id.org/terror/,canonical
 w3id,testalod,https://w3id.org/testalod/,canonical
 w3id,testlink,https://w3id.org/testlink/,canonical
+w3id,ThAO,https://w3id.org/ThAO/,canonical
 w3id,thor,https://w3id.org/thor/,canonical
 w3id,tib,https://w3id.org/tib/,canonical
 w3id,timebank,https://w3id.org/timebank/,canonical
@@ -1224,6 +1275,7 @@ w3id,unileiden,https://w3id.org/unileiden/,canonical
 w3id,unit,https://w3id.org/unit/,canonical
 w3id,UniverseTBD,https://w3id.org/UniverseTBD/,canonical
 w3id,university,https://w3id.org/university/,canonical
+w3id,unocs,https://w3id.org/unocs/,canonical
 w3id,uom,https://w3id.org/uom/,canonical
 w3id,urban-iot,https://w3id.org/urban-iot/,canonical
 w3id,uri4uri,https://w3id.org/uri4uri/,canonical
@@ -1259,8 +1311,13 @@ w3id,vocab,https://w3id.org/vocab/,canonical
 w3id,vocabulary,https://w3id.org/vocabulary/,canonical
 w3id,voic,https://w3id.org/voic/,canonical
 w3id,voldemortkg,https://w3id.org/voldemortkg/,canonical
+w3id,vpa,https://w3id.org/vpa/,canonical
+w3id,VRTI,https://w3id.org/VRTI/,canonical
 w3id,vsat,https://w3id.org/vsat/,canonical
 w3id,vsm,https://w3id.org/vsm/,canonical
+w3id,vvi,https://w3id.org/vvi/,canonical
+w3id,vvr,https://w3id.org/vvr/,canonical
+w3id,vvt,https://w3id.org/vvt/,canonical
 w3id,w2share,https://w3id.org/w2share/,canonical
 w3id,w4ra,https://w3id.org/w4ra/,canonical
 w3id,wallet,https://w3id.org/wallet/,canonical
@@ -1299,6 +1356,7 @@ w3id,xd,https://w3id.org/xd/,canonical
 w3id,xfsc,https://w3id.org/xfsc/,canonical
 w3id,xmal,https://w3id.org/xmal/,canonical
 w3id,yago,https://w3id.org/yago/,canonical
+w3id,yang,https://w3id.org/yang/,canonical
 w3id,yarrrml,https://w3id.org/yarrrml/,canonical
 w3id,ylu,https://w3id.org/ylu/,canonical
 w3id,yxl,https://w3id.org/yxl/,canonical

--- a/tests/input/go-db-xrefs.yaml
+++ b/tests/input/go-db-xrefs.yaml
@@ -149,19 +149,6 @@
       url_syntax: https://www.ebi.ac.uk/biomodels/[example_id]
       example_id: BIOMD:BIOMD0000000045
       example_url: https://www.ebi.ac.uk/biomodels/BIOMD0000000045
-- database: bioRxiv
-  name: bioRxiv
-  synonyms:
-    - BIORXIV
-  generic_urls:
-    - https://www.biorxiv.org/
-  entity_types:
-    - type_name: entity
-      type_id: BET:0000000
-      id_syntax: '[0-9]+'
-      url_syntax: https://www.biorxiv.org/content/[example_id]
-      example_id: bioRxiv:10.1101/530881v2
-      example_url: https://www.biorxiv.org/content/10.1101/530881v2
 - database: BRENDA
   name: BRENDA, The Comprehensive Enzyme Information System
   generic_urls:
@@ -233,9 +220,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: https://researcharchive.calacademy.org/research/ichthyology/catalog/fishcatget.asp?genid=[example_id] OK
+      url_syntax: https://researcharchive.calacademy.org/research/ichthyology/catalog/fishcatget.asp?genid=[example_id]
       example_id: CASGEN:1040
-      example_url: https://researcharchive.calacademy.org/research/ichthyology/catalog/fishcatget.asp?genid=1040   OK
+      example_url: https://researcharchive.calacademy.org/research/ichthyology/catalog/fishcatget.asp?genid=1040
 - database: CASREF
   name: Catalog of Fishes publications database
   generic_urls:
@@ -243,9 +230,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: https://researcharchive.calacademy.org/research/ichthyology/catalog/getref.asp?id=[example_id] OK
+      url_syntax: https://researcharchive.calacademy.org/research/ichthyology/catalog/getref.asp?id=[example_id]
       example_id: CASREF:2031
-      example_url: https://researcharchive.calacademy.org/research/ichthyology/catalog/getref.asp?id=2031 OK
+      example_url: https://researcharchive.calacademy.org/research/ichthyology/catalog/getref.asp?id=2031
 - database: CASSPC
   name: Catalog of Fishes species database
   synonyms:
@@ -522,6 +509,17 @@
       url_syntax: http://dictybase.org/publication/[example_id]
       example_id: dictyBase_REF:10157
       example_url: http://dictybase.org/publication/10157
+- database: DisProt
+  name: DisProt
+  description: Database of intrinsically disordered proteins
+  generic_urls:
+    - https://www.disprot.org
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      url_syntax: https://www.disprot.org/[example_id]
+      example_id: DP00086
+      example_url: https://www.disprot.org/DP00086
 - database: DOI
   name: Digital Object Identifier
   generic_urls:
@@ -567,28 +565,46 @@
       example_id: ECO:0000315
       example_url: http://www.evidenceontology.org/browse/#ECO_0000315
 - database: EcoCyc
-  name: Encyclopedia of E. coli metabolism
+  name: Scientific database for the bacterium Escherichia coli K-12 MG1655
   generic_urls:
-    - http://ecocyc.org/
+    - https://ecocyc.org/
   entity_types:
     - type_name: biological_process
       type_id: GO:0008150
-      id_syntax: EG[0-9]{5}
-      url_syntax: http://biocyc.org/ECOLI/NEW-IMAGE?type=PATHWAY&object=[example_id]
+      id_syntax: ^[A-Za-z0-9+_.%-:]+$
+      url_syntax: https://ecocyc.org/ECOLI/NEW-IMAGE?type=PATHWAY&object=[example_id]
       example_id: EcoCyc:P2-PWY
-      example_url: http://biocyc.org/ECOLI/NEW-IMAGE?type=PATHWAY&object=P2-PWY
+      example_url: https://ecocyc.org/ECOLI/NEW-IMAGE?type=PATHWAY&object=P2-PWY
+    - type_name: protein
+      type_id: PR:000000001
+      id_syntax: ^[A-Za-z0-9+_.%-:]+$
+      url_syntax: https://ecocyc.org/gene?orgid=ECOLI&id=[example_id]
+      example_id: EcoCyc:RBSA-MONOMER
+      example_url: https://ecocyc.org/gene?orgid=ECOLI&id=RBSA-MONOMER
+    - type_name: ribonucleic acid
+      type_id: CHEBI:33697
+      id_syntax: ^[A-Za-z0-9+_.%-:]+$
+      url_syntax: https://ecocyc.org/gene?orgid=ECOLI&id=[example_id]
+      example_id: EcoCyc:EG30086
+      example_url: https://ecocyc.org/gene?orgid=ECOLI&id=EG30086
+    - type_name: protein-containing complex
+      type_id: GO:0032991
+      id_syntax: ^[A-Za-z0-9+_.%-:]+$
+      url_syntax: https://ecocyc.org/ECOLI/NEW-IMAGE?id=[example_id]
+      example_id: EcoCyc:ABC-28-CPLX
+      example_url: https://ecocyc.org/ECOLI/NEW-IMAGE?id=ABC-28-CPLX   
 - database: EcoCyc_REF
-  name: Encyclopedia of E. coli metabolism
+  name: Scientific database for the bacterium Escherichia coli K-12 MG1655
   synonyms:
     - ECOCYC_REF
   generic_urls:
-    - http://ecocyc.org/
+    - https://ecocyc.org/
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://biocyc.org/ECOLI/reference.html?type=CITATION-FRAME&object=[example_id]
+      url_syntax: https://ecocyc.org/ECOLI/reference.html?type=CITATION-FRAME&object=[example_id]
       example_id: EcoCyc_REF:COLISALII
-      example_url: http://biocyc.org/ECOLI/reference.html?type=CITATION-FRAME&object=COLISALII
+      example_url: https://ecocyc.org/ECOLI/reference.html?type=CITATION-FRAME&object=COLISALII
 - database: EcoliWiki
   name: EcoliWiki from EcoliHub
   description: EcoliHub\'s subsystem for community annotation of E. coli K-12
@@ -777,7 +793,6 @@
 - database: FB
   name: FlyBase
   synonyms:
-    - FlyBase
     - FLYBASE
   rdf_uri_prefix: http://identifiers.org/flybase/
   generic_urls:
@@ -789,17 +804,42 @@
       url_syntax: http://flybase.org/reports/[example_id].html
       example_id: FB:FBgn0000024
       example_url: http://flybase.org/reports/FBgn0000024.html
+    - type_name: reference
+      type_id: BET:0000000
+      id_syntax: FBrf[0-9]{7}
+      url_syntax: http://flybase.org/reports/[example_id].htm
+      example_id: FBrf0193169
+      example_url: https://flybase.org/reports/FBrf0193169.htm      
 - database: FBbt
   name: Drosophila gross anatomy
   rdf_uri_prefix: http://purl.obolibrary.org/obo/FBbt_
   generic_urls:
     - http://flybase.org/
   entity_types:
-    - type_name: entity
-      type_id: BET:0000000
+    - type_name: cell
+      type_id: GO:0005623
+      id_syntax: '[0-9]{8}'
       url_syntax: http://flybase.org/cgi-bin/fbcvq.html?query=FBbt:[example_id]
-      example_id: FBbt:00005177
-      example_url: http://flybase.org/cgi-bin/fbcvq.html?query=FBbt:00005177
+      example_id: FBbt:00007002
+      example_url: http://flybase.org/cgi-bin/fbcvq.html?query=FBbt:00007002
+    - type_name: anatomical entity
+      type_id: UBERON:0001062
+      id_syntax: '[0-9]{8}'
+      url_syntax: http://flybase.org/cgi-bin/fbcvq.html?query=FBbt:[example_id]
+      example_id: FBbt:10000000
+      example_url: http://flybase.org/cgi-bin/fbcvq.html?query=FBbt:10000000
+- database: FBdv
+  name: Drosophila development
+  rdf_uri_prefix: http://purl.obolibrary.org/obo/FBdv_
+  generic_urls:
+    - http://flybase.org/
+  entity_types:
+    - type_name: life cycle stage
+      type_id: UBERON:0000105
+      id_syntax: '[0-9]{8}'
+      url_syntax: http://flybase.org/cgi-bin/fbcvq.html?query=FBdv:[example_id]
+      example_id: FBdv:00007012
+      example_url: http://flybase.org/cgi-bin/fbcvq.html?query=FBdv:00007012
 - database: FMA
   name: Foundational Model of Anatomy
   rdf_uri_prefix: http://purl.obolibrary.org/obo/FMA_
@@ -932,7 +972,7 @@
 - database: GO_REF
   name: Gene Ontology Database references
   generic_urls:
-    - http://current.geneontology.org/metadata/gorefs/index.html
+    - http://geneontology.org/gorefs
   entity_types:
     - type_name: entity
       type_id: BET:0000000
@@ -1167,6 +1207,17 @@
   rdf_uri_prefix: http://purl.obolibrary.org/obo/IAO_
   generic_urls:
     - http://purl.obolibrary.org/obo/iao
+- database: iBB
+  name: iBeetleBase
+  description: RNAi phenotypes for beetle (Tribolium) genes
+  generic_urls:
+    - https://ibeetle-base.uni-goettingen.de/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      url_syntax: https://ibeetle-base.uni-goettingen.de/details|[example_id]
+      example_id: TC006055
+      example_url: https://ibeetle-base.uni-goettingen.de/details/TC006055
 - database: IMG
   name: Integrated Microbial Genomes; JGI web site for genome annotation
   generic_urls:
@@ -1205,7 +1256,7 @@
       id_syntax: EBI-[0-9]+
       url_syntax: https://www.ebi.ac.uk/intact/pages/interactions/interactions.xhtml?query=[example_id]
       example_id: IntAct:EBI-17086
-      example_url: https://www.ebi.ac.uk/intact/pages/interactions/interactions.xhtml?query=EBI-17086      
+      example_url: https://www.ebi.ac.uk/intact/pages/interactions/interactions.xhtml?query=EBI-17086
     - type_name: protein-containing complex
       type_id: GO:0032991
       id_syntax: EBI-[0-9]+
@@ -1214,7 +1265,7 @@
       example_url: http://www.ebi.ac.uk/complexportal/complex/EBI-10205244
 - database: InterPro
   name: InterPro database of protein domains and motifs
-  rdf_uri_prefix: https://registry.identifiers.org/registry/interpro
+  rdf_uri_prefix: http://identifiers.org/interpro/
   synonyms:
     - INTERPRO
     - IPR
@@ -1432,7 +1483,7 @@
       example_url: https://maizegdb.org/gene_center/gene/12098
 - database: MaizeGDB_Locus
   name: MaizeGDB
-  rdf_uri_prefix: https://identifiers.org/maizegdb.locus
+  rdf_uri_prefix: http://identifiers.org/maizegdb.locus/
   generic_urls:
     - https://www.maizegdb.org/
   entity_types:
@@ -1487,6 +1538,7 @@
   entity_types:
     - type_name: protein
       type_id: PR:000000001
+      id_syntax: '^[SCTAGMNU]\d{2}\.([AB]\d{2}|\d{3}|[A-Z]{3})$'
       url_syntax: https://www.ebi.ac.uk/merops/cgi-bin/pepsum?id=[example_id]
       example_id: MEROPS:A08.001
       example_url: https://www.ebi.ac.uk/merops/cgi-bin/pepsum?id=A08.001
@@ -1497,11 +1549,13 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
+      id_syntax: '^[SCTAGMNU]\d+$'
       url_syntax: https://www.ebi.ac.uk/merops/cgi-bin/famsum?family=[example_id]
       example_id: MEROPS_fam:M18
       example_url: https://www.ebi.ac.uk/merops/cgi-bin/famsum?family=M18
     - type_name: protein family
       type_id: NCIT:C20130
+      id_syntax: '^[SCTAGMNU]\d+$'
       url_syntax: https://www.ebi.ac.uk/merops/cgi-bin/famsum?family=[example_id]
       example_id: MEROPS_fam:M18
       example_url: https://www.ebi.ac.uk/merops/cgi-bin/famsum?family=M18
@@ -1522,15 +1576,16 @@
   name: Metabolic Encyclopedia of metabolic and other pathways
   synonyms:
     - METACYC
-  rdf_uri_prefix: https://identifiers.org/metacyc.reaction
+  rdf_uri_prefix: http://identifiers.org/metacyc.reaction/
   generic_urls:
-    - http://metacyc.org/
+    - https://metacyc.org/
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://biocyc.org/META/NEW-IMAGE?type=NIL&object=[example_id]
+      id_syntax: ^[A-Za-z0-9+_.%-:]+$
+      url_syntax: https://biocyc.org/META/NEW-IMAGE?type=NIL&object=[example_id]
       example_id: MetaCyc:GLUTDEG-PWY
-      example_url: http://biocyc.org/META/NEW-IMAGE?type=NIL&object=GLUTDEG-PWY
+      example_url: https://biocyc.org/META/NEW-IMAGE?type=NIL&object=GLUTDEG-PWY
 - database: MGCSC_GENETIC_STOCKS
   name: Maize Genetics and Genomics Database
   generic_urls:
@@ -1551,7 +1606,7 @@
       example_id: MGD:Adcy9
 - database: MGI
   name: Mouse Genome Informatics
-  rdf_uri_prefix: https://identifiers.org/MGI
+  rdf_uri_prefix: http://identifiers.org/MGI/
   generic_urls:
     - http://www.informatics.jax.org/
   entity_types:
@@ -1626,7 +1681,7 @@
     - GeneID
     - LocusID
     - NCBI_Gene
-  rdf_uri_prefix: https://identifiers.org/ncbigene
+  rdf_uri_prefix: http://identifiers.org/ncbigene/
   generic_urls:
     - http://www.ncbi.nlm.nih.gov/
   entity_types:
@@ -1748,16 +1803,28 @@
       type_id: BET:0000000
 - database: PANTHER
   name: Protein ANalysis THrough Evolutionary Relationships Classification System
-  rdf_uri_prefix: https://identifiers.org/panther.family
+  rdf_uri_prefix: http://identifiers.org/panther.family/
   generic_urls:
     - http://www.pantherdb.org/
   entity_types:
     - type_name: protein family
       type_id: NCIT:C20130
-      id_syntax: PTN[0-9]{9}|PTHR[0-9]{5}_[A-Z0-9]+
+      id_syntax: PTN[0-9]{9}|PTHR[0-9]{5}|PTHR[0-9]{5}:SF[0-9]+
       url_syntax: http://www.pantherdb.org/panther/lookupId.jsp?id=[example_id]
       example_id: PANTHER:PTHR11455
       example_url: http://www.pantherdb.org/panther/lookupId.jsp?id=PTHR10000
+- database: orcid
+  name: Open Researcher and Contributor
+  description: ORCID (Open Researcher and Contributor ID) is an open, non-profit, community-based effort to create and maintain a registry of unique identifiers for individual researchers.
+  generic_urls:
+    - https://orcid.org/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      id_syntax: ^\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$
+      url_syntax: https://orcid.org/[example_id]
+      example_id: orcid:0000-0003-4423-4370
+      example_url: https://orcid.org/0000-0003-4423-4370
 - database: ParkinsonsUK-UCL
   name: Parkinsons Disease Gene Ontology Initiative
   generic_urls:
@@ -1811,20 +1878,20 @@
   name: Pfam database of protein families
   description: Pfam is a collection of protein families represented by sequence alignments and hidden Markov models (HMMs)
   generic_urls:
-    - http://pfam.xfam.org
+    - https://www.ebi.ac.uk/interpro/entry/pfam
   entity_types:
     - type_name: sequence feature
       type_id: SO:0000110
       id_syntax: PF[0-9]{5}
-      url_syntax: https://pfam.xfam.org/family/[example_id]
+      url_syntax: https://www.ebi.ac.uk/interpro/entry/pfam/[example_id]
       example_id: Pfam:PF00046
-      example_url: https://pfam.xfam.org/family/PF00069
+      example_url: https://www.ebi.ac.uk/interpro/entry/pfam/PF00069
     - type_name: polypeptide region
       type_id: SO:0000839
       id_syntax: PF[0-9]{5}
-      url_syntax: https://pfam.xfam.org/family/[example_id]
+      url_syntax: https://www.ebi.ac.uk/interpro/entry/pfam/[example_id]
       example_id: Pfam:PF00046
-      example_url: https://pfam.xfam.org/family/PF00069
+      example_url: https://www.ebi.ac.uk/interpro/entry/pfam/PF00069
 - database: PharmGKB
   name: Pharmacogenetics and Pharmacogenomics Knowledge Base
   generic_urls:
@@ -1842,6 +1909,18 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
+- database: PHI-base
+  name: Pathogen-Host Interactions Database
+  description: PHI-base catalogues experimentally verified pathogenicity, virulence and effector genes from fungal, Oomycete and bacterial pathogens, which infect animal, plant, fungal and insect hosts.
+  generic_urls:
+    - http://www.phi-base.org/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      id_syntax: 'PHI:[0-9]+'
+      url_syntax: http://www.phi-base.org/searchFacet.htm?queryTerm=PHI:[example_id]
+      example_id: PHI:3
+      example_url: http://www.phi-base.org/searchFacet.htm?queryTerm=PHI:3
 - database: PIR
   name: Protein Information Resource
   generic_urls:
@@ -1875,7 +1954,7 @@
       example_url: http://www.plantsystematics.org/imagebyid_37658.html
 - database: PMCID
   name: Pubmed Central
-  synonyms: 
+  synonyms:
     - PMC
   generic_urls:
     - https://www.ncbi.nlm.nih.gov/pmc/
@@ -1938,13 +2017,13 @@
       example_url: http://planteome.org/po_ref/00001
 - database: PlasmoDB
   name: PlasmoDB
-  rdf_uri_prefix: https://identifiers.org/plasmodb
+  rdf_uri_prefix: http://identifiers.org/plasmodb/
   generic_urls:
     - https://plasmodb.org
   entity_types:
     - type_name: gene
       type_id: SO:0000704
-      id_syntax: PF3D7_[0-9]{7})
+      id_syntax: PF3D7_[0-9]{7}
       url_syntax: https://plasmodb.org/plasmo/app/record/gene/[example_id]
       example_id: PF3D7_1467300
       example_url: https://plasmodb.org/plasmo/app/record/gene/PF3D7_1467300
@@ -1957,7 +2036,7 @@
       type_id: BET:0000000
 - database: PomBase
   name: PomBase
-  rdf_uri_prefix: https://identifiers.org/pombase
+  rdf_uri_prefix: http://identifiers.org/pombase/
   generic_urls:
     - https://www.pombase.org/
   entity_types:
@@ -1978,7 +2057,7 @@
 - database: PPI
   name: Pseudomonas syringae community annotation project
   generic_urls:
-    - http://www.pseudomonas-syringae.org/    
+    - http://www.pseudomonas-syringae.org/
   entity_types:
     - type_name: entity
       type_id: BET:0000000
@@ -1993,9 +2072,9 @@
     - type_name: protein
       type_id: PR:000000001
       id_syntax: ([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}){1}(-[0-9]+){0,1}|[0-9]{9}
-      url_syntax: https://proconsortium.org/app/entry/PR_[example_id]
+      url_syntax: https://purl.obolibrary.org/obo/PR_[example_id]
       example_id: PR:Q64445
-      example_url: https://proconsortium.org/app/entry/PR_Q64445
+      example_url: https://purl.obolibrary.org/obo/PR_000060258
 - database: PRINTS
   name: PRINTS compendium of protein fingerprints
   generic_urls:
@@ -2128,7 +2207,7 @@
   synonyms:
     - REACTOME
     - REAC
-  rdf_uri_prefix: https://identifiers.org/reactome
+  rdf_uri_prefix: http://identifiers.org/reactome/
   generic_urls:
     - https://www.reactome.org/
   entity_types:
@@ -2200,7 +2279,7 @@
   synonyms:
     - RAD
     - RGDID
-  rdf_uri_prefix: https://identifiers.org/rgd
+  rdf_uri_prefix: http://identifiers.org/rgd/
   generic_urls:
     - https://rgd.mcw.edu/
   entity_types:
@@ -2209,7 +2288,7 @@
       id_syntax: '[0-9]{4,7}'
       url_syntax: https://rgd.mcw.edu/rgdweb/search/search.html?term=[example_id]
       example_id: RGD:2004
-      example_url: https://rgd.mcw.edu/rgdweb/search/search.html?term=2004          
+      example_url: https://rgd.mcw.edu/rgdweb/search/search.html?term=2004
 - database: RHEA
   name: Rhea, the Annotated Reactions Database
   description: Rhea is a manually annotated database of chemical reactions. All data in Rhea is freely accessible and available for anyone to use.
@@ -2300,16 +2379,16 @@
   name: Saccharomyces Genome Database
   synonyms:
     - SGDID
-  rdf_uri_prefix: https://identifiers.org/sgd
+  rdf_uri_prefix: http://identifiers.org/sgd/
   generic_urls:
     - http://www.yeastgenome.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: S[0-9]{9}
-      url_syntax:  https://www.yeastgenome.org/locus/[example_id]
+      url_syntax:  https://www.yeastgenome.org/search?q=[example_id]&is_quick=true
       example_id: SGD:S000006169
-      example_url: https://www.yeastgenome.org/locus/S000006169
+      example_url: https://www.yeastgenome.org/search?q=S000006169&is_quick=true
 - database: SGD_LOCUS
   name: Saccharomyces Genome Database
   generic_urls:
@@ -2317,9 +2396,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://www.yeastgenome.org/locus/[example_id]/overview
+      url_syntax: https://www.yeastgenome.org/search?q=[example_id]&is_quick=true
       example_id: SGD_LOCUS:GAL4
-      example_url: http://www.yeastgenome.org/locus/S000006169/overview
+      example_url: https://www.yeastgenome.org/search?q=S000006169&is_quick=true
 - database: SGD_REF
   name: Saccharomyces Genome Database
   generic_urls:
@@ -2330,11 +2409,21 @@
       url_syntax:  http://www.yeastgenome.org/reference/[example_id]/overview
       example_id: SGD_REF:S000049602
       example_url: http://www.yeastgenome.org/reference/S000049602/overview
+- database: SGD_PWY
+  name: Saccharomyces Genome Database YeastPathways
+  generic_urls:
+    - https://pathway.yeastgenome.org/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      url_syntax:  https://www.yeastgenome.org/locus/[example_id]
+      example_id: SGD_PWY:CYSTEINE-SYN2-PWY
+      example_url: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?type=NIL&object=SERSYN-PWY
 - database: SGN
   name: Sol Genomics Network
   synonyms:
     - SGN_gene
-  rdf_uri_prefix: https://identifiers.org/sgn
+  rdf_uri_prefix: http://identifiers.org/sgn/
   generic_urls:
     - https://www.sgn.cornell.edu/
   entity_types:
@@ -2383,14 +2472,20 @@
       type_id: SO:0000400
       id_syntax: \d{7}
       url_syntax: http://www.sequenceontology.org/browser/current_svn/term/SO:[example_id]
-      example_id: SO:0000195
-      example_url: http://www.sequenceontology.org/browser/current_svn/term/SO:0001850
+      example_id: SO:0000400
+      example_url: http://www.sequenceontology.org/browser/current_svn/term/SO:0000400
     - type_name: sequence feature
       type_id: SO:0000110
       id_syntax: \d{7}
       url_syntax: http://www.sequenceontology.org/browser/current_svn/term/SO:[example_id]
-      example_id: SO:0000195
-      example_url: http://www.sequenceontology.org/browser/current_svn/term/SO:0001850
+      example_id: SO:0000307
+      example_url: http://www.sequenceontology.org/browser/current_svn/term/SO:0000307
+    - type_name: sequence motif
+      type_id: SO:0001683
+      id_syntax: \d{7}
+      url_syntax: http://www.sequenceontology.org/browser/current_svn/term/SO:[example_id]
+      example_id: SO:0001166
+      example_url: http://www.sequenceontology.org/browser/current_svn/term/SO:0001166
 - database: Soy_gene
   name: SoyBase
   generic_urls:
@@ -2456,7 +2551,7 @@
       type_id: BET:0000000
 - database: TAIR
   name: The Arabidopsis Information Resource
-  rdf_uri_prefix: https://identifiers.org/tair.locus
+  rdf_uri_prefix: http://identifiers.org/tair.locus/
   generic_urls:
     - http://www.arabidopsis.org/
   entity_types:
@@ -2478,10 +2573,10 @@
       url_syntax: http://arabidopsis.org/servlets/TairObject?accession=[example_id]
       example_id: TAIR:locus:2146653
       example_url: http://arabidopsis.org/servlets/TairObject?accession=locus:2146653
-- database: taxon
+- database: NCBITaxon
   name: NCBI Taxonomy
   synonyms:
-    - NCBITaxon
+    - taxon
     - ncbi_taxid
   rdf_uri_prefix: http://purl.obolibrary.org/obo/NCBITaxon_
   generic_urls:
@@ -2490,7 +2585,7 @@
     - type_name: entity
       type_id: BET:0000000
       url_syntax: http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=[example_id]
-      example_id: taxon:7227
+      example_id: NCBITaxon:7227
       example_url: http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3702
 - database: TC
   name: Transport Protein Database
@@ -2505,7 +2600,7 @@
       example_url: http://www.tcdb.org/tcdb/index.php?tc=9.A.4.1.1
 - database: TGD
   name: Tetrahymena Genome Database
-  rdf_uri_prefix: https://identifiers.org/tgd
+  rdf_uri_prefix: http://identifiers.org/tgd/
   generic_urls:
     - http://www.ciliate.org/
   entity_types:
@@ -2557,10 +2652,10 @@
       type_id: BET:0000000
       url_syntax: http://dendrome.ucdavis.edu/treegenes/protein/view_protein.php?id=[example_id]
       example_id: TreeGenes:254
-      example_url: http://dendrome.ucdavis.edu/treegenes/protein/view_protein.php?id=254  
+      example_url: http://dendrome.ucdavis.edu/treegenes/protein/view_protein.php?id=254
 - database: TriTrypDB
   name: TriTrypDB
-  rdf_uri_prefix: https://identifiers.org/tritrypdb
+  rdf_uri_prefix: http://identifiers.org/tritrypdb/
   generic_urls:
     - https://tritrypdb.org/
   entity_types:
@@ -2569,7 +2664,7 @@
       id_syntax: ((LmjF|LinJ|LmxM|LINF)\.[0-9]{2}\.[0-9]{4})|(Tb[0-9]+\.[A-Za-z0-9]+\.[0-9]+)|(Tb\.[0-9]{6}\.[0-9]+)|
       url_syntax: https://tritrypdb.org/tritrypdb/app/record/gene/[example_id]
       example_id: Tb927.1.630
-      example_url: https://tritrypdb.org/tritrypdb/app/record/gene/Tb927.1.630   
+      example_url: https://tritrypdb.org/tritrypdb/app/record/gene/Tb927.1.630
 - database: UBERON
   name: Uber-anatomy ontology
   description: A multi-species anatomy ontology
@@ -2670,13 +2765,13 @@
 - database: UniProtKB
   name: Universal Protein Knowledgebase
   description: A central repository of protein sequence and function created by joining the information contained in Swiss-Prot, TrEMBL, and PIR database
-  rdf_uri_prefix: https://identifiers.org/uniprot
+  rdf_uri_prefix: http://identifiers.org/uniprot/
   generic_urls:
     - http://www.uniprot.org
   entity_types:
     - type_name: protein
       type_id: PR:000000001
-      id_syntax: ([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z]([0-9][A-Z][A-Z0-9]{2}){1,2}[0-9])((-[0-9]+)|:PRO_[0-9]{10}|:VAR_[0-9]{6}){0,1}
+      id_syntax: ([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z]([0-9][A-Z][A-Z0-9]{2}){1,2}[0-9])((-[0-9]+)|-PRO_[0-9]{10}|-VAR_[0-9]{6}){0,1}
       url_syntax: https://www.uniprot.org/uniprot/[example_id]
       example_id: UniProtKB:P51587
       example_url: https://www.uniprot.org/uniprot/
@@ -2715,6 +2810,17 @@
       id_syntax: UR[0-9]{9}|MF_[0-9]{5}|PIRNR[0-9]{6}|PRU[0-9]{5}|RU[0-9]{6}
       example_id: UniRule:UR000107224
       example_url: https://www.uniprot.org/unirule/UR000107224
+- database: ARBA
+  name: ARBA machine learning models for automatic annotation of UniProtKB unreviewed entries
+  generic_urls:
+    - https://www.uniprot.org/arba/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      url_syntax: https://www.uniprot.org/arba/[example_id]
+      id_syntax: ARBA[0-9]{8}
+      example_id: ARBA:ARBA00000001
+      example_url: https://www.uniprot.org/arba/ARBA00000001
 - database: VZ
   name: ViralZone
   generic_urls:
@@ -2729,7 +2835,7 @@
   name: WormBase database of nematode biology
   synonyms:
     - WormBase
-  rdf_uri_prefix: https://identifiers.org/wb
+  rdf_uri_prefix: http://identifiers.org/wormbase/
   generic_urls:
     - http://www.wormbase.org/
   entity_types:
@@ -2784,7 +2890,7 @@
       url_syntax: http://www.wormbase.org/get?name=[example_id]
       example_id: WBbt:0005792
       example_url: http://www.wormbase.org/get?name=WBbt:0005792
-    - type_name: metazoan anatomical entity
+    - type_name: anatomical entity
       type_id: UBERON:0001062
       id_syntax: '[0-9]{7}'
       url_syntax: http://www.wormbase.org/get?name=[example_id]
@@ -2836,34 +2942,34 @@
       example_url: https://en.wikipedia.org/w/index.php?title=Fallopian_tube&oldid=998395727
 - database: Xenbase
   name: Xenbase
-  rdf_uri_prefix: https://identifiers.org/xenbase
+  rdf_uri_prefix: http://identifiers.org/xenbase/
   generic_urls:
     - http://www.xenbase.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-GENE-6255962
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-GENE-6255962
+      example_url: http://www.xenbase.org/entry/XB-GENE-6255962
     - type_name: morpholino oligo
       type_id: SO:0000034
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-MORPHOLINO-17250301
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-MORPHOLINO-17250301
+      example_url: http://www.xenbase.org/entry/XB-MORPHOLINO-17250301
     - type_name: transgene
       type_id: SO:0000902
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-TRANSGENE-17326811
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-TRANSGENE-17326811
+      example_url: http://www.xenbase.org/entry/XB-TRANSGENE-17326811
     - type_name: strain
       type_id: EFO:0005135
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-LINE-1248
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-LINE-1248
+      example_url: http://www.xenbase.org/entry/XB-LINE-1248
 - database: YeastFunc
   name: Yeast Function
   generic_urls:
@@ -2878,7 +2984,7 @@
     - http://citgenedb.yubiolab.org
 - database: ZFIN
   name: Zebrafish Information Network
-  rdf_uri_prefix: https://identifiers.org/zfin
+  rdf_uri_prefix: http://identifiers.org/zfin/
   generic_urls:
     - http://zfin.org/
   entity_types:
@@ -2921,24 +3027,24 @@
   generic_urls:
     - https://www.animalgenome.org/QTLdb
   description: A database with curated publicly available trait mapping data (QTL and SNP associations) in livestock animal species. The link ID is called QTL_ID on QTLdb data dpownloads.
-  entity_types: 
+  entity_types:
     - type_name: QTL
       type_id: QTL_ID:0000000
       url_syntax: https://www.animalgenome.org/QTLdb/q?id=[example_id]
       id_syntax: \d+
-      example_id: 23155
+      example_id: Animal_QTLdb:23155
       example_url: https://www.animalgenome.org/QTLdb/q?id=23155
 - database: Animal_CorrDB
   name: CorrDB
   generic_urls:
     - https://www.animalgenome.org/CorrDB
   description: A database with curated publicly available trait correlation and inheritability data in livestock animal species. The link ID is called  The link ID is called Corr_ID on CorrDB data downloads.
-  entity_types: 
+  entity_types:
     - type_name: Correlation
       type_id: CorrID:000000
       url_syntax: https://www.animalgenome.org/CorrDB/q/?id=[example_id]
       id_syntax: \d+
-      example_id: 37232
+      example_id: Animal_CorrDB:37232
       example_url: https://www.animalgenome.org/CorrDB/q/?id=37232
 - database: AlphaFold
   name: AlphaFold Protein Structure Database
@@ -2947,7 +3053,7 @@
   entity_types:
     - type_name: protein
       type_id: PR:000000001
-      id_syntax: ([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z]([0-9][A-Z][A-Z0-9]{2}){1,2}[0-9])((-[0-9]+)|:PRO_[0-9]{10}|:VAR_[0-9]{6}){0,1}
+      id_syntax: ([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z]([0-9][A-Z][A-Z0-9]{2}){1,2}[0-9])((-[0-9]+)|-PRO_[0-9]{10}|-VAR_[0-9]{6}){0,1}
       url_syntax: https://alphafold.ebi.ac.uk/entry/[example_id]
       example_id: AlphaFold:Q5VSL9
       example_url: https://alphafold.ebi.ac.uk/entry/Q5VSL9
@@ -2961,3 +3067,15 @@
       url_syntax: https://www.japonicusdb.org/gene/[example_id]
       example_id: JaponicusDB:SJAG_01143
       example_url: https://www.japonicusdb.org/gene/SJAG_01143
+- database: TreeGrafter
+  name: TreeGrafter-generated GO annotations
+  rdf_uri_prefix: http://identifiers.org/panther.family/
+  generic_urls:
+    - http://www.pantherdb.org/
+  entity_types:
+    - type_name: protein family
+      type_id: NCIT:C20130
+      id_syntax: PTN[0-9]{9}|PTHR[0-9]{5}|PTHR[0-9]{5}:SF[0-9]+
+      url_syntax: http://www.pantherdb.org/panther/lookupId.jsp?id=[example_id]
+      example_id: PANTHER:PTHR11455
+      example_url: http://www.pantherdb.org/panther/lookupId.jsp?id=PTHR10000

--- a/tests/test_core/test_prefixmaps.py
+++ b/tests/test_core/test_prefixmaps.py
@@ -182,7 +182,6 @@ class TextPrefixMaps(unittest.TestCase):
             self.assertEqual(pm[pfx], exp)
             self.assertEqual(pmi[exp], pfx)
 
-
     def test_synonyms(self):
         # prefixmaps prioritizes GO prefix resolution over bioregistry in terms of adding canonical tags.
         canonical = "PMID:1234"

--- a/tests/test_core/test_prefixmaps.py
+++ b/tests/test_core/test_prefixmaps.py
@@ -182,12 +182,10 @@ class TextPrefixMaps(unittest.TestCase):
             self.assertEqual(pm[pfx], exp)
             self.assertEqual(pmi[exp], pfx)
 
-    # def test_meta(self):
-    #     ctxts = load_contexts_meta()
-    # print(ctxts)
 
     def test_synonyms(self):
-        canonical = "PUBMED:1234"
+        # prefixmaps prioritizes GO prefix resolution over bioregistry in terms of adding canonical tags.
+        canonical = "PMID:1234"
         converter = prefixmaps.load_converter("merged")
         # TODO "pmid:1234", "pubmed:1234"
         others = ["PMID:1234", "MEDLINE:1234", canonical]


### PR DESCRIPTION
Note: the biggest change for merged.csv in this release, is that we specify "PMID" as the canonical prefix for PubMed.  

Please comment if this is a breaking change for you @amc-corey-cox @kevinschaper 